### PR TITLE
Changes to work with sphinx build + content fixes

### DIFF
--- a/chapter1/answers.md
+++ b/chapter1/answers.md
@@ -3,7 +3,8 @@
 #### 1. Entering `SELECT my_name = 'Timothy' != 'Benjamin';` returns an error. Try adding one character to make it return `{true}`.
 
 Answer: change `my_name =` to `my_name :=`. This will assign the string 'Timothy' to `my_name`, and then it will compare it to `'Benjamin'`, and return `{true}` because they are not equal.
-___
+
+---
 
 #### 2. Try inserting a `City` called Constantinople, but now known as İstanbul.
 
@@ -13,11 +14,15 @@ INSERT City {
   modern_name := 'İstanbul' # Comma after here is fine if you want
 };
 ```
-___
+
+---
+
 #### 3. Try displaying all the names of the cities in the database.
 
 This is all you need: `SELECT City.name;`
-___
+
+---
+
 #### 4. Try selecting all the `City` types along with their `name` and `modern_name` properties, but change `.name` to say `old_name` and change `modern_name` to say `name_now`.
 
 ```edgeql
@@ -29,7 +34,8 @@ SELECT City {
 
 Of course, this will not change the name of the properties. `old_name` and `name_now` only show up in this one query.
 
-___
+---
+
 #### 5. Will typing `SelecT City;` produce an error?
 
 No, because keywords are case insensitive.

--- a/chapter1/answers.md
+++ b/chapter1/answers.md
@@ -7,7 +7,7 @@ ___
 
 #### 2. Try inserting a `City` called Constantinople, but now known as İstanbul.
 
-```
+```edgeql
 INSERT City {
   name := 'Constantinople',
   modern_name := 'İstanbul' # Comma after here is fine if you want
@@ -20,7 +20,7 @@ This is all you need: `SELECT City.name;`
 ___
 #### 4. Try selecting all the `City` types along with their `name` and `modern_name` properties, but change `.name` to say `old_name` and change `modern_name` to say `name_now`.
 
-```
+```edgeql
 SELECT City {
   old_name := .name,
   name_now := .modern_name,

--- a/chapter1/index.md
+++ b/chapter1/index.md
@@ -379,6 +379,8 @@ Of course, Jonathan Harker has been inserted with a connection to every city in 
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. Entering `SELECT my_name = 'Timothy' != 'Benjamin';` returns an error. Try adding one character to make it return `{true}`.
 2. Try inserting a `City` called Constantinople, but now known as İstanbul.
 3. Try displaying all the names of the cities in the database. (Hint: you can do it in a single line of code and won't need `{}` to do it)
@@ -386,5 +388,7 @@ Of course, Jonathan Harker has been inserted with a connection to every city in 
 5. Will typing `SelecT City;` produce an error?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 2: [Jonathan Harker arrives in Romania.](../chapter2/index.md)

--- a/chapter1/index.md
+++ b/chapter1/index.md
@@ -2,7 +2,7 @@
 
 In the beginning of the book we see the main character Jonathan Harker, a young lawyer who is going to meet a client. The client is a rich man named Count Dracula who lives somewhere in Eastern Europe. Jonathan still doesn't know that Count Dracula is a vampire, so he's enjoying the trip to a new part of Europe. The book begins with Jonathan writing in his journal as he travels. The parts that are good for a database in **bold**:
 
->**3 May**. **Bistritz**.—Left **Munich** at **8:35 P.M.**, on **1st May**, arriving at **Vienna** early next morning; should have arrived at 6:46, but train was an hour late. **Buda-Pesth** seems a wonderful place, from the glimpse which I got of it from the train...
+> **3 May**. **Bistritz**.—Left **Munich** at **8:35 P.M.**, on **1st May**, arriving at **Vienna** early next morning; should have arrived at 6:46, but train was an hour late. **Buda-Pesth** seems a wonderful place, from the glimpse which I got of it from the train...
 
 ## Schema, object types
 
@@ -10,7 +10,7 @@ This is already a lot of information, and it helps us start to think about our d
 
 - Some kind of City or Location type. These types that we can create are called [object types](https://www.edgedb.com/docs/datamodel/objects#object-types), made out of properties and links. What properties should a City type have? Perhaps a name and a location, and sometimes a different name or spelling. Bistritz for example is now called Bistrița (it's in Romania), and Buda-Pesth is now written Budapest.
 - Some kind of Person type. We need it to have a name, and also a way to track the places that the person visited.
- 
+
 To make a type inside a schema, just use the keyword `type` followed by the type name, then `{}` curly brackets. Our `Person` type will start out like this:
 
 ```sdl
@@ -33,7 +33,7 @@ With `required property name` our `Person` objects are always guaranteed to have
 MissingRequiredError: missing value for required property default::Person.name
 ```
 
-A `str` is just a string, and goes inside either single quotes: `'Jonathan Harker'` or double quotes: `"Jonathan Harker"`. The `\` escape character before a quote  makes EdgeDB treat it like just another letter: `'Jonathan Harker\'s journal'`.
+A `str` is just a string, and goes inside either single quotes: `'Jonathan Harker'` or double quotes: `"Jonathan Harker"`. The `\` escape character before a quote makes EdgeDB treat it like just another letter: `'Jonathan Harker\'s journal'`.
 
 An `array` is a collection of the same type, and our array here is an array of `str`s. We want it to look like this: `["Bistritz", "Vienna", "Buda-Pesth"]`. The idea is to easily search later and see which character has visited where.
 
@@ -58,7 +58,7 @@ We haven't created our database yet, though. There are two small steps that we n
 CREATE DATABASE dracula;
 ```
 
-Then we type ```\c dracula``` to connect to it.
+Then we type `\c dracula` to connect to it.
 
 Lastly, we we need to do a migration. This will give the database the structure we need to start interacting with it. Migrations are not difficult with EdgeDB:
 
@@ -82,13 +82,13 @@ Here's the `City` type we just made with syntax highlighting:
 
 ## Selecting
 
-Here are three operators in EdgeDB that have the `=` sign: 
+Here are three operators in EdgeDB that have the `=` sign:
 
-- `:=` is used to declare, 
+- `:=` is used to declare,
 - `=` is used to check equality (not `==`),
 - `!=` is the opposite of `=`.
 
-Let's try them out with `SELECT`. `SELECT` is the main query command in EdgeDB, and you use it to see results based on the input that comes after it. 
+Let's try them out with `SELECT`. `SELECT` is the main query command in EdgeDB, and you use it to see results based on the input that comes after it.
 
 By the way, keywords in EdgeDB are case insensitive, so `SELECT`, `select` and `SeLeCT` are all the same. But using capital letters is the normal practice for databases so we'll continue to use them that way.
 
@@ -119,7 +119,7 @@ The output is `{false}`, then `{true}`. Of course, you can just write `SELECT 'J
 
 ## Inserting objects
 
-Let's get back to the schema. Later on we can think about adding time zones and locations for the cities for our imaginary game. But in the meantime, we will add some items to the database using `INSERT`. 
+Let's get back to the schema. Later on we can think about adding time zones and locations for the cities for our imaginary game. But in the meantime, we will add some items to the database using `INSERT`.
 
 Don't forget to separate each property by a comma, and finish the `INSERT` with a semicolon. EdgeDB also prefers two spaces for indentation.
 
@@ -226,7 +226,6 @@ SELECT City {
 
 This gives the output:
 
-
 ```
 {
   Object {name: 'Vienna', modern_name: {}},
@@ -331,7 +330,7 @@ INSERT Person {
 };
 ```
 
-We haven't filtered anything, so it will put all the `City` types in there. Now let's see the places that Jonathan has visited. The code below is almost but not quite what we need: 
+We haven't filtered anything, so it will put all the `City` types in there. Now let's see the places that Jonathan has visited. The code below is almost but not quite what we need:
 
 ```edgeql
 select Person {

--- a/chapter10/index.md
+++ b/chapter10/index.md
@@ -357,28 +357,32 @@ With this, the name becomes Johnny plus a number, namely the number of character
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. Try inserting two `NPC` types in one insert with the following `name`, `first_appearance` and `last_appearance` information.
 
-`{('Jimmy the Bartender', '1887-09-10', '1887-09-11'), ('Some friend of Jonathan Harker', '1887-07-08', '1887-07-09')`
+   `{('Jimmy the Bartender', '1887-09-10', '1887-09-11'), ('Some friend of Jonathan Harker', '1887-07-08', '1887-07-09')`
 
 2. Here are two more `NPC`s to insert, except the last one has an empty set (she's not dead). What problem are we going to have?
 
-`{('Dracula\'s Castle visitor', '1887-09-10', '1887-09-11'), ('Old lady from Bistritz', '1887-05-08', {})`
+   `{('Dracula\'s Castle visitor', '1887-09-10', '1887-09-11'), ('Old lady from Bistritz', '1887-05-08', {})`
 
 3. How would you order the `Person` types by last letter of their names?
 
 4. Try inserting an `NPC` with the name `''`. Now how would you do the same query in question 3?
 
-Hint: the length of `''` is 0, which may be a problem.
+   Hint: the length of `''` is 0, which may be a problem.
 
 5. How would you insert a `Country` called Slovakia, or Slovak Republic if the name is already taken?
 
 6. How would you insert a character called 'Jonathan Harker', or 'Jonathan Harker 2', 'Jonathan Harker 3' etc. if the name has been taken?
 
-Hint: `LIKE` can help. 
+   Hint: `LIKE` can help.
 
-Bonus challenge: give the function [`contains()`](https://www.edgedb.com/docs/edgeql/funcops/generic#function::std::contains) a try to see if you can do the same thing. This function will return `{true}` for example from `SELECT contains('Jonathan Harker', 'Jonathan');`.
+   Bonus challenge: give the function [`contains()`](https://www.edgedb.com/docs/edgeql/funcops/generic#function::std::contains) a try to see if you can do the same thing. This function will return `{true}` for example from `SELECT contains('Jonathan Harker', 'Jonathan');`.
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 11: [How can Van Helsing help them without sounding crazy?](../chapter11/index.md)

--- a/chapter10/index.md
+++ b/chapter10/index.md
@@ -27,7 +27,7 @@ INSERT City {
 };
 ```
 
-But for the rest of them it would be nice to update everything at the same time. 
+But for the rest of them it would be nice to update everything at the same time.
 
 ## Working with tuples and arrays
 
@@ -166,14 +166,14 @@ WITH cities := City.population
 );
 ```
 
-This used quite a few functions: 
+This used quite a few functions:
 
 - `count()` to count the number of items,
-- `all()` to return `{true}` if all items match and `{false}` otherwise, 
-- `sum()` to add them all together, 
-- `max()` to give the highest value, 
-- `min()` to give the lowest one, 
-- `math::mean()` to give the average, 
+- `all()` to return `{true}` if all items match and `{false}` otherwise,
+- `sum()` to add them all together,
+- `max()` to give the highest value,
+- `min()` to give the lowest one,
+- `math::mean()` to give the average,
 - `any()` to return `{true}` if any item matches and `{false}` otherwise, and
 - `math::stddev()` for the standard deviation.
 
@@ -327,13 +327,13 @@ WITH johnnies := (SELECT NPC FILTER .name LIKE '%Johnny%'),
  name := 'Johnny' ++ <str>(count(johnnies))
  });
 ```
- 
+
 Let's look at it step by step:
- 
+
 `WITH johnnies := (SELECT NPC FILTER .name LIKE '%Johnny%'),` Here we select all the `NPC` types that have Johnny in their name.
- 
+
 Then a normal insert:
- 
+
 ```
 INSERT NPC {
  name := 'Johnny'

--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -201,20 +201,24 @@ And if you take out the filter and just write `SELECT Person` for the function, 
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you write a function called `lucy()` that just returns all the `NPC` types matching the name 'Lucy Westenra'?
 
 2. How would you write a function that takes two strings and returns `Person` types with names that match it?
 
-Hint: try using `SET OF Person` as the return type.
+   Hint: try using `SET OF Person` as the return type.
 
 3. What will the output of this be?
 
-`SELECT {'Jonathan', 'Arthur'} ++ {' loves '} ++ {'Mina', 'Lucy'} ++ {' but '} ++ {'Dracula', 'The inkeeper'} ++ {' doesn\'t love '} ++ {'Mina', 'Jonathan'};`
+   `SELECT {'Jonathan', 'Arthur'} ++ {' loves '} ++ {'Mina', 'Lucy'} ++ {' but '} ++ {'Dracula', 'The inkeeper'} ++ {' doesn\'t love '} ++ {'Mina', 'Jonathan'};`
 
 4. How would you make a function that tells you how many times larger one city is than another?
 
 5. Will `SELECT (City.population + City.population)` and `SELECT ((SELECT City.population) + (SELECT City.population))` produce different results?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 12: [Lucy one night: "Funny, what's that flapping against the window? Sounds like a bat or something..."](../chapter12/index.md)

--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -2,7 +2,7 @@
 
 > Dr. Van Helsing thinks that Lucy is being visited by a vampire. He doesn't tell the others yet because they won't believe him, but says they should close the windows and put garlic everywhere. They are confused, but Dr. Seward tells them to listen: Dr. Van Helsing is the smartest person he knows. It works, and Lucy gets better. But one night Lucy's mother walks into the room and thinks: "This place smells terrible! I'll open the windows for some fresh air." The next day Lucy wakes up pale and sick again. Every time someone makes a mistake like this Dracula gets in her room, and every time the men give Lucy their blood to help her get better. Meanwhile, Renfield continues to try to eat living things and Dr. Seward can't understand him. Then one day he didn't want to talk, only saying: “I don’t want to talk to you: you don’t count now; the Master is at hand.”
 
-We are starting to see more and more events in the book with various characters. Some events have the three men and Dr. Van Helsing together, others have just Lucy and Dracula. Previous events had Jonathan Harker and Dracula, Jonathan Harker and the three women, and so on. In our game, we could use a sort of `Event` type to group everything together: the people, the time, the place, and so on. 
+We are starting to see more and more events in the book with various characters. Some events have the three men and Dr. Van Helsing together, others have just Lucy and Dracula. Previous events had Jonathan Harker and Dracula, Jonathan Harker and the three women, and so on. In our game, we could use a sort of `Event` type to group everything together: the people, the time, the place, and so on.
 
 This `Event` type is a bit long, but it would be the main type for our events in the game so it needs to be detailed. We can put it together like this:
 
@@ -17,13 +17,13 @@ type Event {
   property east -> bool;
   property url := 'https://geohack.toolforge.org/geohack.php?params=' ++ <str>.exact_location.0 ++ ' N ' ++ <str>.exact_location.1 ++ ' ' ++ 'E' if .east = true else 'W';
 }
-```    
+```
 
 You can see that most of the properties are `required`, because an `Event` type is not useful if it doesn't have all the information we need. It will always need a description, a time, place, and people participating. The interesting part is the `url` property: it's a computable that gives us an exact url for the location if we want. This one is not `required` because not every event in the book is in a perfectly known location.
 
 The url that we are generating needs to know whether a location is east or west of Greenwich, and also whether they are north or south. Here is the url for Bistritz, for example:
 
-```https://geohack.toolforge.org/geohack.php?pagename=Bistri%C8%9Ba&params=47_8_N_24_30_E```
+`https://geohack.toolforge.org/geohack.php?pagename=Bistri%C8%9Ba&params=47_8_N_24_30_E`
 
 Luckily for us, the events in the book all take place in the north part of the planet. So `N` is always going to be there. But sometimes they are east of Greenwich and sometimes west. To decide between east and west, we can use a simple `bool`. Then in the `url` property we put all the properties together to create a link, and finish it off with 'E' if `east` is `true`, and 'W' otherwise.
 
@@ -164,7 +164,7 @@ Source: [user quartl on Wikipedia](https://en.wikipedia.org/wiki/Cartesian_produ
 
 This means that if we do a `SELECT` on `Person` for our `fight()` function, it will run the function following this formula:
 
-- `{the number of items in the first set}` * `{the number of items in the second set}`
+- `{the number of items in the first set}` \* `{the number of items in the second set}`
 
 So if there are two in the first set, and three in the second, it will run the function six times.
 
@@ -195,7 +195,7 @@ Here is the output. It's a total of nine fights, where each person in Set 1 figh
 
 And if you take out the filter and just write `SELECT Person` for the function, you will get well over 100 results. EdgeDB by default will only show the first 100, displaying this after showing you 100 results:
 
-```  ... (further results hidden `\set limit 100`)```
+`` ... (further results hidden `\set limit 100`)``
 
 [Here is all our code so far up to Chapter 11.](code.md)
 

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -13,7 +13,7 @@ Last chapter, we used the `fight()` function for some characters, but most only 
 Jonathan Harker is just a human but is still quite strong. We'll give him a strength of 5. We'll treat that as the maximum strength for a human, except Renfield who is a bit unique. Every other human should have a strength between 1 and 5. EdgeDB has a random function called `std::rand()` that gives a `float64` in between 0.0 and 1.0. There is another function called `round()` that rounds numbers, so we'll use that too, and finally cast it to an `<int16>`. Our input looks like this:
 
 ```
-SELECT <int16>round((random() * 5)); 
+SELECT <int16>round((random() * 5));
 ```
 
 So now we'll use this to update our Person types and give them all a random strength.
@@ -21,11 +21,11 @@ So now we'll use this to update our Person types and give them all a random stre
 ```
 WITH random_5 := (SELECT <int16>round((random() * 5)))
  # WITH isn't necessary - just making the query prettier
- 
+
 UPDATE Person
   FILTER NOT EXISTS .strength
   SET {
-    strength := random_5 
+    strength := random_5
 };
 ```
 
@@ -107,7 +107,7 @@ So that's how function overloading works - you can create functions with the sam
 
 You see overloading in a lot of existing functions, such as [sum](https://www.edgedb.com/docs/edgeql/funcops/set#function::std::sum) which takes in all numeric types and returns the sum. [std::to_datetime](https://www.edgedb.com/docs/edgeql/funcops/datetime#function::std::to_datetime) has even more interesting overloading with all sorts of inputs to create a `datetime`.
 
-`fight()` was pretty fun to make, but that sort of function is better done on the gaming side. So let's make a function that we might actually use. Since EdgeQL is a query language, the most useful functions are usually ones that make queries shorter. 
+`fight()` was pretty fun to make, but that sort of function is better done on the gaming side. So let's make a function that we might actually use. Since EdgeQL is a query language, the most useful functions are usually ones that make queries shorter.
 
 Here is a simple one that tells us if a `Person` type has visited a `Place` or not:
 
@@ -172,7 +172,6 @@ fight(names: str, one: int16, two: Person) -> str
 
 You would delete them with `DROP fight(one: Person, two: Person)` and `DROP fight(names: str, one: int16, two: Person)`. The `-> str` part isn't needed.
 
-
 ## More about Cartesian products - the coalescing operator
 
 Now let's learn more about Cartesian products in EdgeDB. You might be surprised to see that even a single `{}` input always results in an output of `{}`, but this is the way that Cartesian products work. Remember, a `{}` has a length of 0 and anything multiplied by 0 is also 0. For example, let's try to add the names of places that start with b and those that start with f.
@@ -212,7 +211,7 @@ Okay, one more time, this time making sure that the `{}` empty set is of type `s
 ```
 edgedb> SELECT {'Buda-Pesth', 'Bistritz'} ++ <str>{};
 {}
-edgedb>  
+edgedb>
 ```
 
 Good, so we have manually confirmed that using `{}` with another set always returns `{}`. But what if we want to:
@@ -241,9 +240,9 @@ So let's get back to our original query, this time with the coalescing operator:
 ```
 WITH b_places := (SELECT Place FILTER Place.name ILIKE 'b%'),
      f_places := (SELECT Place FILTER Place.name ILIKE 'f%'),
-     SELECT 
-       b_places.name ++ ' ' ++ f_places.name IF EXISTS b_places.name AND EXISTS f_places.name 
-     ELSE 
+     SELECT
+       b_places.name ++ ' ' ++ f_places.name IF EXISTS b_places.name AND EXISTS f_places.name
+     ELSE
        b_places.name ?? f_places.name;
 ```
 
@@ -255,14 +254,14 @@ This returns:
 
 That's better.
 
-But now back to Cartesian products. Remember, when we add or concatenate sets we are working with *every item in each set* separately. So if we change the query to search for places that start with b (Buda-Pesth and Bistritz) and m (Munich):
+But now back to Cartesian products. Remember, when we add or concatenate sets we are working with _every item in each set_ separately. So if we change the query to search for places that start with b (Buda-Pesth and Bistritz) and m (Munich):
 
 ```
 WITH b_places := (SELECT Place FILTER Place.name ILIKE 'b%'),
      m_places := (SELECT Place FILTER Place.name ILIKE 'm%'),
-     SELECT 
-       b_places.name ++ ' ' ++ m_places.name IF EXISTS b_places.name AND EXISTS m_places.name 
-     ELSE 
+     SELECT
+       b_places.name ++ ' ' ++ m_places.name IF EXISTS b_places.name AND EXISTS m_places.name
+     ELSE
        b_places.name ?? m_places.name;
 ```
 
@@ -272,7 +271,7 @@ Then we'll get this result:
 {'Buda-Pesth Munich', 'Bistritz Munich'}
 ```
 
-instead of something like 'Buda-Peth, Bistritz, Munich'. 
+instead of something like 'Buda-Peth, Bistritz, Munich'.
 
 To get the output that we want, we can use two more functions:
 

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -10,8 +10,8 @@ But there is good news for us, because we are going to keep learning about Carte
 
 Last chapter, we used the `fight()` function for some characters, but most only have `{}` for the `strength` property. That's why the Innkeeper defeated Dracula, which is obviously not what would really happen.
 
-Jonathan Harker is just a human but is still quite strong. We'll give him a strength of 5. We'll treat that as the maximum strength for a human, except Renfield who is a bit unique. Every other human should have a strength between 1 and 5. EdgeDB has a random function called `std::rand()` that gives a `float64` in between 0.0 and 1.0. There is another function called `round()` that rounds numbers, so we'll use that too, and finally cast it to an '<int16>'. Our input looks like this:
- 
+Jonathan Harker is just a human but is still quite strong. We'll give him a strength of 5. We'll treat that as the maximum strength for a human, except Renfield who is a bit unique. Every other human should have a strength between 1 and 5. EdgeDB has a random function called `std::rand()` that gives a `float64` in between 0.0 and 1.0. There is another function called `round()` that rounds numbers, so we'll use that too, and finally cast it to an `<int16>`. Our input looks like this:
+
 ```
 SELECT <int16>round((random() * 5)); 
 ```

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -310,37 +310,39 @@ This gives us the result:
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. Consider these two functions. Will EdgeDB accept the second one?
 
-First function:
+   First function:
 
-```
-function gives_number(input: int64) -> int64
- using(input);
-```
+   ```
+   function gives_number(input: int64) -> int64
+   using(input);
+   ```
 
-Second function:
+   Second function:
 
-```
-function gives_number(input: int64) -> int32
- using(<int32>input);
-```
+   ```
+   function gives_number(input: int64) -> int32
+   using(<int32>input);
+   ```
 
 2. How about these two functions? Will EdgeDB accept the second one?
 
-First function:
+   First function:
 
-```
-function make64(input: int16) -> int64
-  using(input);
-```  
+   ```
+   function make64(input: int16) -> int64
+     using(input);
+   ```
 
-Second function:
+   Second function:
 
-```
-function make64(input: int32) -> int64
-  using(input);
-```
+   ```
+   function make64(input: int32) -> int64
+     using(input);
+   ```
 
 3. Will `SELECT {} ?? {3, 4} ?? {5, 6};` work?
 
@@ -349,5 +351,7 @@ function make64(input: int32) -> int64
 5. Trying to make a single string of everyone's name with `SELECT array_join(array_agg(Person.name));` isn't working. What's the problem?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 13: [One of the men gives Lucy his blood again to try to save her. Will it be enough?](../chapter13/index.md)

--- a/chapter13/index.md
+++ b/chapter13/index.md
@@ -114,7 +114,7 @@ So if you wanted to have all the `MinorVampire` types automatically deleted when
 
 Now let's look at some tips for making queries.
 
-## Using DISTINCT, \__type__
+## Using DISTINCT, \_\_type\_\_
 
 - `DISTINCT`
 
@@ -175,7 +175,7 @@ This shows us the objects that match, and of course they are `NPC` and `MinorVam
 But there is a settingy you can use to always see the type when you make a query: just type `\set introspect-types on`. Once you do that, you'll always see the type name instead of just `Object`. Now even a simple search like this will give us the type:
 
 ```
-SELECT Person 
+SELECT Person
   {
 name
 } FILTER .name = 'Lucy Westenra';
@@ -201,9 +201,9 @@ type Ship {
 }
 ```
 
-First, here is the simplest `INTROSPECT` query: 
+First, here is the simplest `INTROSPECT` query:
 
-```SELECT (INTROSPECT Ship.name);``` 
+`SELECT (INTROSPECT Ship.name);`
 
 This query isn't very useful to us but it does show how it works: it returns `{'default::Ship'}`. Note that `INTROSPECT` and the type go inside brackets; it's sort of a `SELECT` expression for types that you then select again to capture.
 
@@ -258,11 +258,11 @@ SELECT (INTROSPECT Ship) {
 };
 ```
 
-So what this will give is: 
+So what this will give is:
 
-1) The type name for `Ship`, 
-2) The properties, and their names. But we also use `target`, which is what a property points to (the part after the `->`). For example, the target of `property name -> str` is `std::str`. And we want the target name too; without it we'll get an output like `target: schema::ScalarType {id: 00000000-0000-0000-0000-000000000100}`.
-3) The links and their names, and the targets to the links...and the names of *their* targets too.
+1. The type name for `Ship`,
+2. The properties, and their names. But we also use `target`, which is what a property points to (the part after the `->`). For example, the target of `property name -> str` is `std::str`. And we want the target name too; without it we'll get an output like `target: schema::ScalarType {id: 00000000-0000-0000-0000-000000000100}`.
+3. The links and their names, and the targets to the links...and the names of _their_ targets too.
 
 With all that together, we get something readable and useful. The output looks like this:
 
@@ -292,7 +292,7 @@ SELECT (INTROSPECT Ship) {
   name,
   properties: {name, target: {name}},
   links: {name, target: {name}},
-};             
+};
 ```
 
 [Here is all our code so far up to Chapter 13.](code.md)

--- a/chapter13/index.md
+++ b/chapter13/index.md
@@ -299,26 +299,30 @@ SELECT (INTROSPECT Ship) {
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you insert an `NPC` named 'Mr. Swales' who has visited the `City` called 'York', the `Country` called 'England', and the `OtherPlace` called 'Whitby Abbey'? Try it in a single insert.
 
 2. How readable is this introspect query?
 
-```
-SELECT (INTROSPECT Ship) {
-  name,
-  properties,
-  links
-};
-```
+   ```
+   SELECT (INTROSPECT Ship) {
+     name,
+     properties,
+     links
+   };
+   ```
 
 3. What would be the shortest way to see what links from the `Vampire` type?
 
 4. What do you think the output of `SELECT DISTINCT {1, 2} + {1, 2};` will be?
 
-Hint: don't forget the Cartesian multiplication.
+   Hint: don't forget the Cartesian multiplication.
 
 5. What do you think the output of `SELECT DISTINCT {2, 2} + {2, 2};` will be?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 14: [An old friend returns.](../chapter14/index.md)

--- a/chapter14/index.md
+++ b/chapter14/index.md
@@ -328,18 +328,22 @@ Here is the output:
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you display just the numbers for all the `Person` types? e.g. if there are 20 of them, displaying `1, 2, 3..., 18, 19, 20`.
 
 2. Using reverse lookup, how would you display 1) all the `Place` types (plus their names) that have an `o` in the name and 2) the names of the people that visited them?
 
 3. Using reverse lookup, how would you display all the Person types that will later become `MinorVampire`s?
 
-Hint: Remember, `MinorVampire` has a link back to the vampire's former self.
+   Hint: Remember, `MinorVampire` has a link back to the vampire's former self.
 
 4. How would you give the `MinorVampire` type an annotation called `note` that says `'first_appearance for MinorVampire should always match last_appearance for its matching NPC type'`?
 
 5. How would you see this `note` annotation for `MinorVampire` in a query?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 15: [Time to get revenge.](../chapter15/index.md)

--- a/chapter14/index.md
+++ b/chapter14/index.md
@@ -2,14 +2,14 @@
 
 > Finally there is some good news: Jonathan Harker is alive. After escaping Castle Dracula, he found his way to Budapest in August and then to a hospital, which sent Mina a letter. Mina took a train to the hospital where Jonathan was recovering, and they took a train back to England to the city of Exeter where they got married. Mina sends Lucy a letter from Exeter about the good news...but it arrives too late and Lucy never opens it. Meanwhile, the men visit the graveyard as planned and see vampire Lucy walking around. When Arthur sees her he finally believes Van Helsing, and so do the rest. They now know that vampires are real, and manage to destroy her. Arthur is sad but happy to see that Lucy is no longer forced to be a vampire and can now die in peace.
 
-So we have a new city called Exeter, and adding it is of course easy: 
+So we have a new city called Exeter, and adding it is of course easy:
 
 ```
 INSERT City {
-  name := 'Exeter', 
+  name := 'Exeter',
   population := 40000
 };
-``` 
+```
 
 That's the population of Exeter at the time, and it doesn't have a `modern_name` that is different from the one in the book.
 
@@ -54,7 +54,7 @@ Uh oh, not quite:
 }
 ```
 
-Ah, of course: the `annotations: {name}` part returns the name of the *type*, which is `std::description`. This is where `@` comes in. To get the value inside we write something else: `@value`. The `@` is used to directly access the value inside (the string) instead of just the type name. Let's try one more time:
+Ah, of course: the `annotations: {name}` part returns the name of the _type_, which is `std::description`. This is where `@` comes in. To get the value inside we write something else: `@value`. The `@` is used to directly access the value inside (the string) instead of just the type name. Let's try one more time:
 
 ```
 SELECT (INTROSPECT City) {
@@ -89,7 +89,6 @@ Now we see the actual annotation:
   },
 }
 ```
-
 
 What if we want an annotation with a different name besides `title` and `description`? That's easy, just declare with `abstract annotation` inside the schema and give it a name. We want to add a warning so that's what we'll call it:
 
@@ -131,7 +130,7 @@ And here it is:
 
 ## Even more working with dates
 
-A lot of characters are starting to die now, so let's think about that. We could come up with a method to see who is alive and who is dead, depending on a `cal::local_date`. First let's take a look at the `People` objects we have so far. We can easily count them with `SELECT count(Person)`, which gives `{23}`. 
+A lot of characters are starting to die now, so let's think about that. We could come up with a method to see who is alive and who is dead, depending on a `cal::local_date`. First let's take a look at the `People` objects we have so far. We can easily count them with `SELECT count(Person)`, which gives `{23}`.
 
 There is also a function called [`enumerate()`](https://www.edgedb.com/docs/edgeql/funcops/set#function::std::enumerate) that gives tuples of the index and the set that we give it. We'll use this to compare to our `count()` function to make sure that our number is right.
 
@@ -166,7 +165,7 @@ So now let's use it with `SELECT enumerate(Person.name);` to make sure that we h
 There are only 18? Oh, that's right: the `Crewman` objects don't have a name so they don't show up. How can we get them in the query? We could of course try something fancy like this:
 
 ```
-WITH 
+WITH
   a := array_agg((SELECT enumerate(Person.name))),
   b:= array_agg((SELECT enumerate(Crewman.number))),
   SELECT (a, b);
@@ -208,7 +207,7 @@ So now that everyone has a name, let's use that to see if they are dead or not. 
 ```
 WITH p := (SELECT Person),
   date := <cal::local_date>'1887-08-16',
-  SELECT(p.name, p.last_appearance, 'Dead on ' ++ <str>date ++ '? ' ++ <str>(date > p.last_appearance));  
+  SELECT(p.name, p.last_appearance, 'Dead on ' ++ <str>date ++ '? ' ++ <str>(date > p.last_appearance));
 ```
 
 Here is the output:
@@ -269,13 +268,13 @@ SELECT MinorVampire {
 
 Since there's no `link master -> Vampire`, how do we go backwards to see the `Vampire` type that links to it?
 
-This is where reverse links come in, where we use `.<` instead of `.` and specify the type we are looking for: `[IS Vampire]`. 
+This is where reverse links come in, where we use `.<` instead of `.` and specify the type we are looking for: `[IS Vampire]`.
 
 First let's move out of our `MinorVampire` query and just look at how `.<` works. Here is one example:
 
 ```
 SELECT MinorVampire.<slaves[IS Vampire] {
-  name, 
+  name,
   age
   };
 ```

--- a/chapter15/index.md
+++ b/chapter15/index.md
@@ -8,7 +8,7 @@ This chapter they learned something about vampires: they need to sleep in coffin
 
 - Each place in the world either has coffins doesn't have them,
 - Has coffins = vampires can enter and terrorize the people,
-- If a place has coffins, we should know how many of them there are. 
+- If a place has coffins, we should know how many of them there are.
 
 This sounds like a good case for an abstract type. Here it is:
 
@@ -59,7 +59,7 @@ function can_enter(person_name: str, place: HasCoffins) -> str
   using (
     with vampire := (SELECT Person filter .name = person_name LIMIT 1)
     SELECT vampire.name ++ ' can enter.' IF place.coffins > 0 ELSE vampire.name ++ ' cannot enter.'
-        );   
+        );
 ```
 
 You'll notice that `person_name` in this function actually just takes a string that it uses to select a `Person`. So technically it could say something like 'Jonathan Harker cannot enter'. It has a `LIMIT 1` though, and we can probably trust that the user of the function will use it properly. If we can't trust the user of the function, there are some options:
@@ -88,7 +88,7 @@ Now we can finally call up our function and see if it works:
 
 ```
 SELECT can_enter('Count Dracula', (SELECT City filter .name = 'London'));
-``` 
+```
 
 We get `{'Count Dracula can enter.'}`.
 
@@ -99,7 +99,7 @@ Some other possible ideas for improvement later on for `can_enter()` are:
 
 ## More constraints
 
-Let's look at some more constraints. We've seen `exclusive` and `max_value` already, but there are [some others](https://www.edgedb.com/docs/datamodel/constraints) that we can use as well. 
+Let's look at some more constraints. We've seen `exclusive` and `max_value` already, but there are [some others](https://www.edgedb.com/docs/datamodel/constraints) that we can use as well.
 
 There is one called `max_len_value` that makes sure that a string doesn't go over a certain length. That could be good for our `PC` type, which we created many chapters ago. We only used it once as a test, because we don't have any players yet. We are still just using the book to populate the database with `NPC`s for our imaginary game. `NPC`s won't need this constraint because their names are already decided, but `max_len_value()` is good for `PC`s to make sure that players don't choose crazy names. We'll change it to look like this:
 
@@ -122,7 +122,7 @@ property title -> str {
 }
 ```
 
-For us it's probably not worth it to add a `one_of` constraint though, as there are probably too many titles throughout the book (Count, German *Herr*, etc. etc.).
+For us it's probably not worth it to add a `one_of` constraint though, as there are probably too many titles throughout the book (Count, German _Herr_, etc. etc.).
 
 Another place you could imagine using a `one_of` is in the months, because the book only goes from May to October of the same year. If we had an object type generating a date then you could have this sort of constraint inside it:
 
@@ -138,7 +138,7 @@ Now let's learn about perhaps the most interesting constraint in EdgeDB:
 
 ## expression on: the most flexible constraint
 
-One particularly flexible constraint is called [`expression on`](https://www.edgedb.com/docs/datamodel/constraints#constraint::std::expression), which lets us add any expression we want. After `expression on` you add the expression (in brackets) that must be true to create the type. In other words: "Create this type *as long as* (insert expression here)".
+One particularly flexible constraint is called [`expression on`](https://www.edgedb.com/docs/datamodel/constraints#constraint::std::expression), which lets us add any expression we want. After `expression on` you add the expression (in brackets) that must be true to create the type. In other words: "Create this type _as long as_ (insert expression here)".
 
 Let's say we need a type `Lord` for some reason later on, and all `Lord` types must have the word 'Lord' in their name. We can constrain the type to make sure that this is always the case. For this, we will use a function called [contains()](https://www.edgedb.com/docs/edgeql/funcops/generic#function::std::contains) that looks like this:
 
@@ -184,8 +184,8 @@ SELECT (
    name
    }
  };
- ```
- 
+```
+
 Now that `.name` contains the substring `Lord`, it works like a charm:
 
 ```

--- a/chapter15/index.md
+++ b/chapter15/index.md
@@ -305,18 +305,22 @@ Beautiful! All the information is right there.
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you create a type called Horse with a `required property name -> str` that can only be 'Horse'?
 
 2. How would you let the user know that it needs to be called 'Horse'?
 
 3. How would you make sure that `name` for type `PC` is always between 5 and 30 characters in length?
 
-Try it first with `expression on`.
+   Try it first with `expression on`.
 
 4. How would you make a function called `display_coffins` that pulls up all the `HasCoffins` types with more than 0 coffins?
 
 5. How would you make it without touching the schema?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 16: [Could Renfield be of help?](../chapter16/index.md)

--- a/chapter16/index.md
+++ b/chapter16/index.md
@@ -1,6 +1,6 @@
 # Chapter 16 - Is Renfield telling the truth?
 
-> Arthur Holmwood's father has died and now Arthur is the head of the house. His new title is Lord Godalming, and he has a lot of money. With this money he helps the team to find the houses where Dracula has hidden his boxes. 
+> Arthur Holmwood's father has died and now Arthur is the head of the house. His new title is Lord Godalming, and he has a lot of money. With this money he helps the team to find the houses where Dracula has hidden his boxes.
 
 > Meanwhile, Van Helsing is curious and asks John Seward if he can meet Renfield. He is surprised to see that Renfield is very educated and well-spoken. Renfield talks about Van Helsing's research, politics, history, and so on - he doesn't seem crazy at all! But later, Renfield doesn't want to talk and just calls him an idiot. Very confusing. And one night, Renfield was very serious and asks them to let him leave. He says: “Don’t you know that I am sane and earnest...a sane man fighting for his soul? Oh, hear me! hear me! Let me go! let me go! let me go!” They want to believe him, but can't trust him. Finally Renfield stops and calmly says: “Remember, later on, that I did what I could to convince you tonight.”
 
@@ -33,7 +33,7 @@ This is very convenient for us. With this we can make a type that holds a date a
 
 The [`index on (.excerpt)`](https://www.edgedb.com/docs/datamodel/indexes#indexes) part is new, and means to create an index to make future queries faster. Lookups are faster with `index on` because now the database doesn't need to scan the whole set of objects in sequence to find objects that match.
 
-We could do this for certain other types too - it might be good for types like `Place` and `Person`. 
+We could do this for certain other types too - it might be good for types like `Place` and `Person`.
 
 Note: `index` is good in limited quantities, but you don't want to index everything. Here is why:
 
@@ -190,10 +190,10 @@ Now the `n`s are all gone:
 You can also split by `\n` to split by new line. You can't see it but from the point of view of the computer every new line has a `\n` in it. So this:
 
 ```
-SELECT str_split('Oh, hear me! 
-hear me! 
-Let me go! 
-let me go! 
+SELECT str_split('Oh, hear me!
+hear me!
+Let me go!
+let me go!
 let me go!', '\n');
 ```
 
@@ -210,12 +210,12 @@ SELECT re_match_all('[Tt]o-?night', 'Dracula is an old book, so the word tonight
 {['tonight'], ['to-night'], ['Tonight'], ['tonight'], ['to-night']}
 ```
 
-The function signature is `std::re_match(pattern: str, string: str) -> array<str>`, and as you can see the pattern comes first, then the string. The pattern `[Tt]o-?night` means words that: 
+The function signature is `std::re_match(pattern: str, string: str) -> array<str>`, and as you can see the pattern comes first, then the string. The pattern `[Tt]o-?night` means words that:
 
-- start with a `T` or a `t`, 
-- then have an `o`, 
-- maybe have an `-` in between, 
-- and end in `night`, 
+- start with a `T` or a `t`,
+- then have an `o`,
+- maybe have an `-` in between,
+- and end in `night`,
 
 so it gives: `{['tonight'], ['to-night']}`.
 

--- a/chapter16/index.md
+++ b/chapter16/index.md
@@ -237,24 +237,28 @@ type City extending Place {
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you split all the `Person` names into two strings if they have two words, and ignore any that don't have exactly two words?
 
 2. How would you display all the `Person` names and where the string 'ma' is in their name?
 
-Hint: this uses the function `find()`.
+   Hint: this uses the function `find()`.
 
 3. How would you index on the `pen_name` property for type Person?
 
-Hint: try using `describe type Person as SDL` to take a look at it the `pen_name` property again.
+   Hint: try using `describe type Person as SDL` to take a look at it the `pen_name` property again.
 
 4. How would you display the name of every `Person` in uppercase followed by a space and then the same name in lowercase?
 
-Hint: the [str_repeat()](https://www.edgedb.com/docs/edgeql/funcops/string#function::std::str_repeat) function could help (though there is more than one way to do it)
+   Hint: the [str_repeat()](https://www.edgedb.com/docs/edgeql/funcops/string#function::std::str_repeat) function could help (though there is more than one way to do it)
 
 5. How would you use `re_match_all()` to display all the `Person.name`s with `Crewman` in the name? e.g. Crewman 1, Crewman 2, etc.
 
-Hint: [Here are some basic concepts](https://en.wikipedia.org/w/index.php?title=Regular_expression&oldid=988356211#Basic_concepts) if you want a quick read on regular expressions.
+   Hint: [Here are some basic concepts](https://en.wikipedia.org/w/index.php?title=Regular_expression&oldid=988356211#Basic_concepts) if you want a quick read on regular expressions.
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 17: [The truth about Renfield.](../chapter17/index.md)

--- a/chapter17/index.md
+++ b/chapter17/index.md
@@ -466,12 +466,16 @@ Here's the output:
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you display every NPC's name, strength, name and population of cities visited, and age (displaying 0 if age = `{}`)? Try it on a single line.
 
 2. The query in 1. showed a lot of numbers without any context. What should we do?
 
-3. Renfield is now dead and needs a `last_appearance`. Try writing a function called `make_dead(person_name: str, date: str) ->  Person` that lets you just write the character name and date to do it.
+3. Renfield is now dead and needs a `last_appearance`. Try writing a function called `make_dead(person_name: str, date: str) -> Person` that lets you just write the character name and date to do it.
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 18: [Jonathan the detective.](../chapter18/index.md)

--- a/chapter17/index.md
+++ b/chapter17/index.md
@@ -1,18 +1,17 @@
 # Chapter 17 - Poor Renfield. Poor Mina.
 
-> Last chapter Dr. Seward and Dr. Van Helsing wanted to let Renfield out, but couldn't trust him. But it turns out that Renfield was telling the truth! That night, Dracula found out that they were destroying his coffins and decided to attack Mina. He succeeded, and now Mina is slowly turning into a vampire. She is still human, but has a connection with Dracula now. 
+> Last chapter Dr. Seward and Dr. Van Helsing wanted to let Renfield out, but couldn't trust him. But it turns out that Renfield was telling the truth! That night, Dracula found out that they were destroying his coffins and decided to attack Mina. He succeeded, and now Mina is slowly turning into a vampire. She is still human, but has a connection with Dracula now.
 
 > The group finds Renfield in a pool of blood, dying. Renfield is sorry and tells them the truth. He was in communication with Dracula and thought that he would help him become a vampire too, so he let him in the house. But once inside Dracula ignored him, and headed for Mina's room. Renfield attacked Dracula to try to stop him from hurting her, but Dracula was much stronger and won.
 
 > Van Helsing does not give up though, and has a good idea. If Mina is now connected to Dracula, what happens if he uses hypnotism on her? Could that work? He takes out his pocket watch and tells her: "Please concentrate on this watch. You are beginning to feel sleepy...what do you feel? Think about the man who attacked you, try to feel where he is..."
-
 
 ## Named tuples
 
 Remember the function `fight()` that we made? It was overloaded to take either `(Person, Person)` or `(str, Person)` as input. Let's give it Dracula and Renfield:
 
 ```
-WITH 
+WITH
   dracula := (SELECT Person FILTER .name = 'Count Dracula'),
   renfield := (SELECT Person FILTER .name = 'Renfield'),
 SELECT fight(dracula, renfield);
@@ -33,7 +32,7 @@ That's not bad, but there is a way to make it clearer: we can give names to the 
 
 ```
 WITH fighters := (
-  dracula := (SELECT Person FILTER .name = 'Count Dracula'), 
+  dracula := (SELECT Person FILTER .name = 'Count Dracula'),
   renfield := (SELECT Person FILTER .name = 'Renfield')),
   SELECT fight(fighters.dracula, fighters.renfield);
 ```
@@ -42,7 +41,7 @@ Here's one more example of a named tuple:
 
 ```
 WITH minor_vampires := (
-  women := (SELECT MinorVampire FILTER .name LIKE '%Woman%'), 
+  women := (SELECT MinorVampire FILTER .name LIKE '%Woman%'),
   lucy := (SELECT MinorVampire FILTER .name LIKE '%Lucy%')),
 SELECT (minor_vampires.women.name, minor_vampires.lucy.name);
 ```
@@ -62,7 +61,7 @@ SELECT ( # Put the whole update inside
   last_appearance := <cal::local_date>'1887-10-03'
 }) # then use it to call up name and last_appearance
   {
-  name, 
+  name,
   last_appearance
   };
 ```
@@ -79,7 +78,7 @@ will return `{true}`.
 
 ## Putting abstract types together
 
-Wherever there are vampires, there are vampire hunters. Sometimes they will destroy their coffins, and other times vampires will build more. So it would be cool to create a quick function called `change_coffins()` to change the number of coffins in a place. With this function we could write something like `change_coffins('London', -13)` to reduce it by 13, for example. But the problem right now is this: 
+Wherever there are vampires, there are vampire hunters. Sometimes they will destroy their coffins, and other times vampires will build more. So it would be cool to create a quick function called `change_coffins()` to change the number of coffins in a place. With this function we could write something like `change_coffins('London', -13)` to reduce it by 13, for example. But the problem right now is this:
 
 - the `HasCoffins` type is an abstract type, with one property: `coffins`
 - places that can have coffins are `Place` and all the types from it, plus `Ship`,
@@ -119,14 +118,14 @@ abstract type Place extending HasNameAndCoffins {
 }
 ```
 
-Finally, we can change our `can_enter()` function. This one needed a `HasCoffins` type before: 
+Finally, we can change our `can_enter()` function. This one needed a `HasCoffins` type before:
 
 ```
     function can_enter(person_name: str, place: HasCoffins) -> str
       using (
         with vampire := (SELECT Person FILTER .name = person_name LIMIT 1),
         SELECT vampire.name ++ ' can enter.' IF place.coffins > 0 ELSE vampire.name ++ ' cannot enter.'
-            );   
+            );
 ```
 
 But now that `HasNameAndCoffins` holds `name`, the user can now just enter a string. We'll change it to this:
@@ -134,11 +133,11 @@ But now that `HasNameAndCoffins` holds `name`, the user can now just enter a str
 ```
 function can_enter(person_name: str, place: str) -> str
   using (
-  with 
+  with
     vampire := (SELECT Person FILTER .name = person_name LIMIT 1),
     place := (SELECT HasNameAndCoffins FILTER .name = place LIMIT 1)
     SELECT vampire.name ++ ' can enter.' IF place.coffins > 0 ELSE vampire.name ++ ' cannot enter.'
-    );   
+    );
 ```
 
 And now we can just enter `can_enter('Count Dracula', 'Munich')` to get `'Count Dracula cannot enter.'`. That makes sense: Dracula didn't bring any coffins there.
@@ -192,7 +191,7 @@ alias CrewmanInBulgaria := Crewman {
 }
 ```
 
-You'll notice right away that `name` and `current_location` inside the alias are separated by commas, not semicolons. That's a clue that this isn't creating a new type: it's just creating a *shape* on top of the existing `Crewman` type. For the same reason, you can't do an `INSERT CrewmanInBulgaria`, because there is no such type. It gives this error:
+You'll notice right away that `name` and `current_location` inside the alias are separated by commas, not semicolons. That's a clue that this isn't creating a new type: it's just creating a _shape_ on top of the existing `Crewman` type. For the same reason, you can't do an `INSERT CrewmanInBulgaria`, because there is no such type. It gives this error:
 
 ```
 error: cannot insert into expression alias 'default::CrewmanInBulgaria'
@@ -217,7 +216,7 @@ SELECT CrewmanInBulgaria {
   };
 ```
 
-And now we see the same `Crewman` types under their `CrewmanInBulgaria` alias: with *Gospodin* added to their name and linked to the `Country` type we just inserted.
+And now we see the same `Crewman` types under their `CrewmanInBulgaria` alias: with _Gospodin_ added to their name and linked to the `Country` type we just inserted.
 
 ```
 {

--- a/chapter18/index.md
+++ b/chapter18/index.md
@@ -307,20 +307,24 @@ Much better!
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. During the time of Dracula, the Goldmark was used in Germany. One Goldmark had 100 Pfennig. How would you make this type?
 
 2. Try adding two annotations to this type. One should be called `description` and mention that `One mark = 100 Pfennig`. The other should be called `note` and mention the types of coins there are.
 
-[Here are the types of coins](https://en.wikipedia.org/w/index.php?title=German_gold_mark&oldid=972733514#Base_metal_coins): 1, 2, 5, 10, 20, 25 Pfennig coins.
+   [Here are the types of coins](https://en.wikipedia.org/w/index.php?title=German_gold_mark&oldid=972733514#Base_metal_coins): 1, 2, 5, 10, 20, 25 Pfennig coins.
 
 3. A vampire named Godbrand has just attacked a village and turned three villagers into `MinorVampire`s. How would you insert all four of them at once?
 
-Here is their data (name, date of birth (`first_appearance`, date turned into a MinorVampire (`last_appearance`):
+   Here is their data (name, date of birth (`first_appearance`, date turned into a MinorVampire (`last_appearance`):
 
-('Fritz Frosch', '1850-01-15', '1887-09-11'),
-('Levanta Sinyeva', '1862-02-24', '1887-09-11'),
-('김훈', '1860-09-09', '1887-09-11'),
+   ('Fritz Frosch', '1850-01-15', '1887-09-11'),
+   ('Levanta Sinyeva', '1862-02-24', '1887-09-11'),
+   ('김훈', '1860-09-09', '1887-09-11'),
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 19: [Only Mina can tell them where Dracula has gone.](../chapter19/index.md)

--- a/chapter18/index.md
+++ b/chapter18/index.md
@@ -49,13 +49,13 @@ type Pound extending Currency {
     overloaded required property major {
         default := 'pound'
     }
-    overloaded required property minor { 
+    overloaded required property minor {
         default := 'shilling'
     }
     overloaded required property minor_conversion {
         default := 20
     }
-    overloaded property sub_minor { 
+    overloaded property sub_minor {
         default := 'pence'
     }
     overloaded property sub_minor_conversion {
@@ -168,7 +168,7 @@ SELECT(INSERT Dollar {
 };
 ```
 
-Here's the output: `{default::Dollar {total_money: 100.55}}`. Perfect! 
+Here's the output: `{default::Dollar {total_money: 100.55}}`. Perfect!
 
 Not that we need this `Dollar` type in our game: in our schema it would be `type Dollar extending Currency`.
 

--- a/chapter19/index.md
+++ b/chapter19/index.md
@@ -386,10 +386,14 @@ With the reverse lookup at the end we have another link between `Country` and it
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you display all the `City` names and the names of the `Region` they are in?
 
 2. How about the `City` names plus the names of the `Region` and the name of the `Country` they are in?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 20: [The race against time.](../chapter20/index.md)

--- a/chapter19/index.md
+++ b/chapter19/index.md
@@ -2,19 +2,19 @@
 
 > Van Helsing hypnotises Mina, who is now half vampire and can feel Dracula. He asks her questions:
 
-> “Where are you now?”  
+> “Where are you now?”
 >
-> “I do not know. It is all strange to me!”  
+> “I do not know. It is all strange to me!”
 >
-> “What do you see?”  
+> “What do you see?”
 >
-> “I can see nothing; it is all dark.”  
+> “I can see nothing; it is all dark.”
 >
-> “What do you hear?”  
+> “What do you hear?”
 >
-> “The water... and little waves.”  
+> “The water... and little waves.”
 >
-> “Then you are on a ship?”  
+> “Then you are on a ship?”
 >
 > “Oh, yes!”
 
@@ -41,7 +41,7 @@ type Visit {
 }
 ```
 
-This new ship that Dracula is on is called the `Czarina Catherine` (a Czarina is a Russian queen). Let's use that to insert a few visits from the ships we know. You'll remember that the other ship was called The Demeter and left from Varna towards London. 
+This new ship that Dracula is on is called the `Czarina Catherine` (a Czarina is a Russian queen). Let's use that to insert a few visits from the ships we know. You'll remember that the other ship was called The Demeter and left from Varna towards London.
 
 But first we'll insert a new `Ship` and two new places (`City`s) so we can link them. We know the name of the ship and that there is one coffin in it: Dracula's last coffin. But we don't know about the crew, so we'll just insert this information:
 
@@ -69,7 +69,7 @@ SELECT (INTROSPECT OtherPlace) {
   annotations: {
      @value
    }
-};  
+};
 ```
 
 Let's look at the output to see what we wrote before to make sure that we should use it:
@@ -207,18 +207,18 @@ SELECT Ship.<ship[IS Visit] {
    awake
    }),
  } FILTER .place.name = 'Galatz';
- ```
- 
- Here's the output, including whether vampires are awake or asleep.
- 
- ```
- {
-  default::Visit {
-    place: default::City {name: 'Galatz'},
-    ship: default::Ship {name: 'Czarina Catherine'},
-    date: <cal::local_date>'1887-10-28',
-    time: default::Date {date: '13:00:00', local_time: <cal::local_time>'13:00:00', hour: '13', awake: 'asleep'},
-  },
+```
+
+Here's the output, including whether vampires are awake or asleep.
+
+```
+{
+ default::Visit {
+   place: default::City {name: 'Galatz'},
+   ship: default::Ship {name: 'Czarina Catherine'},
+   date: <cal::local_date>'1887-10-28',
+   time: default::Date {date: '13:00:00', local_time: <cal::local_time>'13:00:00', hour: '13', awake: 'asleep'},
+ },
 }
 ```
 

--- a/chapter2/answers.md
+++ b/chapter2/answers.md
@@ -16,7 +16,7 @@ You can cast with a numeric type, such as `SELECT <int64>'99' + <int64>'1'`. Not
 
 Just add `extending HasAString` to the type, which would now look like this:
 
-```
+```sdl
 abstract type Person extending HasAString {
   required property name -> str;
   multi link places_visited -> City;
@@ -27,7 +27,7 @@ abstract type Person extending HasAString {
 
 Change it to this:
 
-```
+```edgeql
 SELECT Person {
   places_visited: {name}
 };
@@ -35,7 +35,7 @@ SELECT Person {
 
 Don't forget the `:` and remember that spacing doesn't matter, so you could write it this way too:
 
-```
+```edgeql
 SELECT Person {
   places_visited: {
     name

--- a/chapter2/index.md
+++ b/chapter2/index.md
@@ -6,7 +6,7 @@ We continue to read the story as we think about the database we need to store th
 
 Now we are starting to see some detail about the city. Reading the story, we see that we could add another property to `City`, and we will call it `important_places`. That's where places like the **Golden Krone Hotel** could go. We're not sure if the places will be their own types yet, so we'll just make it an array of strings: `property important_places -> array<str>;` We can put the names of important places in there and maybe develop it more later. It will now look like this:
 
-```
+```sdl
 type City {
   required property name -> str;
   property modern_name -> str;
@@ -16,7 +16,7 @@ type City {
 
 Now our original insert for Bistritz will look like this:
 
-```
+```edgeql
 INSERT City {
   name := 'Bistritz',
   modern_name := 'Bistrița',
@@ -32,7 +32,7 @@ Here we see the word `scalar` for the first time: this is a `scalar type` becaus
 
 The other keyword we will see for the first time is `extending`, which means to take a type as a base and extend it. This gives you all the power of the type that you are extending, and adds some more options. We will write our `Transport` type like this:
 
-```
+```sdl
 scalar type Transport extending enum<Feet, Train, HorseDrawnCarriage>;
 ```
 
@@ -42,7 +42,7 @@ This `Transport` type is going to be for player characters in our game, not the 
 
 So now this part of the schema looks like this:
 
-```
+```sdl
 abstract type Person {
   required property name -> str;
   multi link places_visited -> City;
@@ -72,7 +72,7 @@ Also, `SELECT` on an abstract type is just fine - it will select all the types t
 
 Let's also experiment with a player character. We'll make one called Emil Sinclair who starts out traveling by horse-drawn carriage. We'll also just give him `City` so he'll have all three cities.
 
-```
+```edgeql
 INSERT PC {
   name := 'Emil Sinclair',
   places_visited := City,
@@ -82,13 +82,13 @@ INSERT PC {
 
 Note that we didn't just write `HorseDrawnCarriage`, because we have to choose the enum `Transport` and then make a choice of one of the variants. The `<>` angle brackets do *casting*, meaning to change one type into another. EdgeDB won't try to change one type into another unless you ask it to with casting. That's why this won't give us `true`:
 
-```
+```edgeql
 SELECT 'feet' IS Transport;
 ```
 
 We will get an output of `{false}`, because 'feet' is just a `str` and nothing else. But this will work:
 
-```
+```edgeql
 SELECT <Transport>'feet' IS Transport;
 ```
 
@@ -96,8 +96,8 @@ Then we get `{true}`.
 
 You can cast more than once at a time if you need to. This example isn't something you will need to do but shows how you can cast over and over again if you want:
 
-```
-SELECT <str><int64><str><int32>50 is str; 
+```edgeql
+SELECT <str><int64><str><int32>50 is str;
 ```
 
 That also gives us `{true}` because all we did is ask if it is a `str`, which it is. 
@@ -108,7 +108,7 @@ Casting works from right to left, with the final cast on the far left. So `<str>
 
 Finally, let's learn how to `FILTER` before we're done Chapter 2. You can use `FILTER` after the curly brackets in `SELECT` to only show certain results. Let's `FILTER` to only show `Person` types that have the name 'Emil Sinclair':
 
-```
+```edgeql
 SELECT Person {
   name,
   places_visited: {name},
@@ -137,7 +137,7 @@ You can also add `%` on the left and/or right which means match anything before 
 
 Let's `FILTER` to get all the cities that start with a capital B. That means we'll need `LIKE` because it's case-sensitive:
 
-```
+```edgeql
 SELECT City {
   name,
   modern_name,
@@ -162,7 +162,7 @@ So `'Jonathan'[0]` is 'J' and `'Jonathan'[4]` is 't'.
 
 Let's try it:
 
-```
+```edgeql
 SELECT City {
   name,
   modern_name,

--- a/chapter2/index.md
+++ b/chapter2/index.md
@@ -2,7 +2,7 @@
 
 We continue to read the story as we think about the database we need to store the information. The important information is in bold:
 
->Jonathan Harker has found a hotel in **Bistritz**, called the **Golden Krone Hotel**. He gets a welcome letter there from Dracula, who is waiting in his **castle**. Jonathan Harker will have to take a **horse-driven carriage** to get there tomorrow. We also see that Jonathan Harker is from **London**. The innkeeper at the Golden Krone Hotel seems very afraid of Dracula. He doesn't want Jonathan to leave and says it will be dangerous, but Jonathan doesn't listen. An old lady gives Jonathan a golden crucifix and says it will protect him. Jonathan is embarrassed, and takes it to be polite. Jonathan has no idea how much it will help him later.
+> Jonathan Harker has found a hotel in **Bistritz**, called the **Golden Krone Hotel**. He gets a welcome letter there from Dracula, who is waiting in his **castle**. Jonathan Harker will have to take a **horse-driven carriage** to get there tomorrow. We also see that Jonathan Harker is from **London**. The innkeeper at the Golden Krone Hotel seems very afraid of Dracula. He doesn't want Jonathan to leave and says it will be dangerous, but Jonathan doesn't listen. An old lady gives Jonathan a golden crucifix and says it will protect him. Jonathan is embarrassed, and takes it to be polite. Jonathan has no idea how much it will help him later.
 
 Now we are starting to see some detail about the city. Reading the story, we see that we could add another property to `City`, and we will call it `important_places`. That's where places like the **Golden Krone Hotel** could go. We're not sure if the places will be their own types yet, so we'll just make it an array of strings: `property important_places -> array<str>;` We can put the names of important places in there and maybe develop it more later. It will now look like this:
 
@@ -80,7 +80,7 @@ INSERT PC {
 };
 ```
 
-Note that we didn't just write `HorseDrawnCarriage`, because we have to choose the enum `Transport` and then make a choice of one of the variants. The `<>` angle brackets do *casting*, meaning to change one type into another. EdgeDB won't try to change one type into another unless you ask it to with casting. That's why this won't give us `true`:
+Note that we didn't just write `HorseDrawnCarriage`, because we have to choose the enum `Transport` and then make a choice of one of the variants. The `<>` angle brackets do _casting_, meaning to change one type into another. EdgeDB won't try to change one type into another unless you ask it to with casting. That's why this won't give us `true`:
 
 ```edgeql
 SELECT 'feet' IS Transport;
@@ -100,7 +100,7 @@ You can cast more than once at a time if you need to. This example isn't somethi
 SELECT <str><int64><str><int32>50 is str;
 ```
 
-That also gives us `{true}` because all we did is ask if it is a `str`, which it is. 
+That also gives us `{true}` because all we did is ask if it is a `str`, which it is.
 
 Casting works from right to left, with the final cast on the far left. So `<str><int64><str><int32>50` means "50 into an int32 into a string into an int64 into a string". Or you can read it left to right like this: "A string from an int64 from a string from an int32 from the number 50".
 
@@ -117,15 +117,15 @@ SELECT Person {
 
 `FILTER .name` is short for `FILTER Person.name`. You can write `FILTER Person.name` too if you want - it's the same thing.
 
-The output is this: 
+The output is this:
 
 ```
 {Object {name: 'Emil Sinclair', places_visited: {Object {name: 'Munich'}, Object {name: 'Buda-Pesth'}, Object {name: 'Bistritz'}}}}
 ```
 
-Let's filter the cities now. One flexible way to search is with `LIKE` or `ILIKE` to match on parts of a string. 
+Let's filter the cities now. One flexible way to search is with `LIKE` or `ILIKE` to match on parts of a string.
 
-- `LIKE` is case-sensitive: "Bistritz" matches "Bistritz" but "bistritz" does not. 
+- `LIKE` is case-sensitive: "Bistritz" matches "Bistritz" but "bistritz" does not.
 - `ILIKE` is not case-sensitive (the I in ILIKE means **insensitive**), so "Bistritz" matches "BiStRitz", "bisTRITz", etc.
 
 You can also add `%` on the left and/or right which means match anything before or after. Here are some examples with the matched part **in bold**:

--- a/chapter2/index.md
+++ b/chapter2/index.md
@@ -181,27 +181,31 @@ Plus, if you have any `City` types with a name of `''`, even a search for index 
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. Change the following `SELECT` to display `{100}` by casting: `SELECT '99' + '1'`;
 2. Select all the `City` types that start with 'Mu' (case sensitive).
 3. Select the third letter (i.e. index number 2) of the name of every `NPC`.
 4. Imagine an abstract type called `HasAString`:
 
-```
-abstract type HasAString {
-  property string -> str
-  };
-```
+   ```sdl
+   abstract type HasAString {
+     property string -> str
+   };
+   ```
 
-How would you change the `Person` type to extend `HasAString`?
+   How would you change the `Person` type to extend `HasAString`?
 
 5. This query only shows the id numbers of the places visited. How do you show their name?
 
-```
-SELECT Person {
-  places_visited
-};
-```
+   ```edgeql
+   SELECT Person {
+     places_visited
+   };
+   ```
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 3: [Jonathan gets into the carriage and travels into the cold mountains...](../chapter3/index.md)

--- a/chapter3/answers.md
+++ b/chapter3/answers.md
@@ -4,7 +4,7 @@
 
 All it needs is brackets around the `SELECT` - remember, putting it in brackets "captures" the output so it can be used.
 
-```
+```edgeql
 SELECT NPC {
   name,
   cities := (SELECT City.name)
@@ -15,13 +15,13 @@ SELECT NPC {
 
 Right now `City` is just extending `Place`:
 
-```
+```sdl
 type City extending Place;
 ```
 
 So it would need a `required property` for population:
 
-```
+```sdl
 type City extending Place {
   required property population -> int32
 };
@@ -33,7 +33,7 @@ type City extending Place {
 
 You can access `property name` twice by giving it a different name the second time. Let's call it name2:
 
-```
+```edgeql
 SELECT Person {
   name,
   name2 := .name
@@ -44,7 +44,7 @@ SELECT Person {
 
 We haven't seen this constraint but it's easy to guess: with `min_value()` you can do it. With these two constraints, HumanAge must be between 0 and 120:
 
-```
+```sdl
 scalar type HumanAge extending int16 {
   constraint max_value(120);
   constraint min_value(0);
@@ -57,7 +57,7 @@ No, because it's a scalar type and not an object - a `HumanAge` would just be an
 
 But of course, you can select one by casting:
 
-```
+```edgeql
 SELECT <HumanAge>16;
 ```
 
@@ -65,7 +65,7 @@ This gives `{16}`.
 
 You can also see that it is just a different name for an `int16` by trying the following:
 
-```
+```edgeql
 SELECT <HumanAge>16 IS int16;
 SELECT <HumanAge>16 IS HumanAge;
 ```

--- a/chapter3/index.md
+++ b/chapter3/index.md
@@ -174,33 +174,37 @@ Finally, let's insert Hungary and Romania again to finish the chapter. We'll lea
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. This query is trying to display every `NPC` along with the `name` plus every `City` type for each `NPC`, but it's giving an error. What is it missing?
 
-```
-SELECT NPC {
-  name,
-  cities := SELECT City.name
-};
-```
+   ```edgeql
+   SELECT NPC {
+     name,
+     cities := SELECT City.name
+   };
+   ```
 
 2. If the `City` type needed a required property called `population`, what would it look like? What type would 'population' be?
 3. This query wants to display `name` twice for some reason but is giving an error. Can you think of a way to do it?
 
-```
-SELECT Person {
-  name,
-  name
-};
-```
+   ```edgeql
+   SELECT Person {
+     name,
+     name
+   };
+   ```
 
-(Hint: the problem is that the name `name` is being used twice)
+   (Hint: the problem is that the name `name` is being used twice)
 
 4. People keep trying to make characters with negative ages. Can you think of a constraint that can stop this?
 
-Hint: the current constraint is `max_value(120);`
+   Hint: the current constraint is `max_value(120);`
 
 5. Can you insert a HumanAge type?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 4: [Jonathan: "This Count Dracula knows so much about history! I'm glad I came."](../chapter4/index.md)

--- a/chapter3/index.md
+++ b/chapter3/index.md
@@ -2,9 +2,9 @@
 
 In this chapter we are going to start to think about time, as you can see from what Jonathan Harker is doing:
 
->Jonathan Harker has just arrived at Castle Dracula after a ride in the carriage through the mountains. The ride was terrible: there was snow, strange blue fires and wolves everywhere. It was night when he arrived. He meets with Count Dracula, goes inside, and they talk all night. Dracula leaves before the sun rises though, because vampires are hurt by sunlight. Days go by, and Jonathan still doesn't know that he's a vampire. But he does notice something strange: the castle seems completely empty. If Dracula is so rich, where are his servants? Who is making his meals that he finds on the table? But Jonathan finds Dracula's stories of history very interesting, and so far is enjoying his trip.
+> Jonathan Harker has just arrived at Castle Dracula after a ride in the carriage through the mountains. The ride was terrible: there was snow, strange blue fires and wolves everywhere. It was night when he arrived. He meets with Count Dracula, goes inside, and they talk all night. Dracula leaves before the sun rises though, because vampires are hurt by sunlight. Days go by, and Jonathan still doesn't know that he's a vampire. But he does notice something strange: the castle seems completely empty. If Dracula is so rich, where are his servants? Who is making his meals that he finds on the table? But Jonathan finds Dracula's stories of history very interesting, and so far is enjoying his trip.
 
-Now we are completely inside Dracula's castle, so this is a good time to create a `Vampire` type. We can extend it from `abstract type Person` because that type  has `name` and `places_visited`, which are good for `Vampire` too. But vampires are different from humans because they can live forever. One possibility is adding `age` to `Person` so that all the other types can use it too. Then `Person' would look like this:
+Now we are completely inside Dracula's castle, so this is a good time to create a `Vampire` type. We can extend it from `abstract type Person` because that type has `name` and `places_visited`, which are good for `Vampire` too. But vampires are different from humans because they can live forever. One possibility is adding `age` to `Person` so that all the other types can use it too. Then `Person' would look like this:
 
 ```sdl
 abstract type Person {
@@ -85,13 +85,13 @@ SELECT Vampire {
 };
 ```
 
-This gives us: `{Object {places_visited: {Object {name: 'Romania'}}}}` 
+This gives us: `{Object {places_visited: {Object {name: 'Romania'}}}}`
 
 Perfect.
 
 ## Adding constraints
 
-Now let's think about `age` again. It was easy for the `Vampire` type, because they can live forever. But now we want to give `age` to `PC` and `NPC` too, who are humans who don't live forever (we don't want them living up to 32767 years). For this we can add a "constraint" (a limit). Instead of `age`, we'll give them a new type called `HumanAge`. Then we can write `constraint` on it and use [one of the functions](https://edgedb.com/docs/datamodel/constraints) that it can take. We will use `max_value()`. 
+Now let's think about `age` again. It was easy for the `Vampire` type, because they can live forever. But now we want to give `age` to `PC` and `NPC` too, who are humans who don't live forever (we don't want them living up to 32767 years). For this we can add a "constraint" (a limit). Instead of `age`, we'll give them a new type called `HumanAge`. Then we can write `constraint` on it and use [one of the functions](https://edgedb.com/docs/datamodel/constraints) that it can take. We will use `max_value()`.
 
 Here's the signature for `max_value()`:
 
@@ -107,7 +107,7 @@ scalar type HumanAge extending int16 {
 }
 ```
 
-Remember, it's a scalar type because it can only have one value. Then we'll add it to the `NPC` type. 
+Remember, it's a scalar type because it can only have one value. Then we'll add it to the `NPC` type.
 
 ```sdl
 type NPC extending Person {

--- a/chapter3/index.md
+++ b/chapter3/index.md
@@ -6,7 +6,7 @@ In this chapter we are going to start to think about time, as you can see from w
 
 Now we are completely inside Dracula's castle, so this is a good time to create a `Vampire` type. We can extend it from `abstract type Person` because that type  has `name` and `places_visited`, which are good for `Vampire` too. But vampires are different from humans because they can live forever. One possibility is adding `age` to `Person` so that all the other types can use it too. Then `Person' would look like this:
 
-```
+```sdl
 abstract type Person {
   required property name -> str;
   multi link places_visited -> City;
@@ -18,15 +18,15 @@ abstract type Person {
 
 But we don't want `PC`s and `NPC`s to live up to 32767 years, so let's give `age` only to `Vampire` now and think about the other types later. We'll make `Vampire` a type that extends `Person`, and adds age:
 
-```
-type Vampire extending Person {            
+```sdl
+type Vampire extending Person {
   property age -> int16;
 }
 ```
 
 Now we can create Count Dracula. We know that he lives in Romania, but that isn't a city. This is a good time to change the `City` type. We'll change the name to `Place` and make it an `abstract type`, and then `City` can extend from it. We'll also add a `Country` type that does the same thing. Now they look like this:
 
-```
+```sdl
 abstract type Place {
   required property name -> str;
   property modern_name -> str;
@@ -40,7 +40,7 @@ type Country extending Place;
 
 We will need to change `places_visited` in the `Person` type now to be a `Place` instead of a `City`. After all, characters can visit more places than just cities:
 
-```
+```sdl
 abstract type Person {
   required property name -> str;
   multi link places_visited -> Place;
@@ -50,7 +50,7 @@ abstract type Person {
 
 Now it's easy to make a `Country`, just do an insert and give it a name. We'll quickly insert `Country` objects for Hungary and Romania:
 
-```
+```edgeql
 INSERT Country {
   name := 'Hungary'
 };
@@ -63,7 +63,7 @@ INSERT Country {
 
 With these countries added, we are now ready to make Dracula. First we will change `places_visited` in `Person` from `City` to `Place` so that it can include many things: London, Bistritz, Hungary, etc. We only know that Dracula has been in Romania, so we can do a quick `FILTER` when we select it. When doing this, we put the `SELECT` inside `()` brackets. The brackets are necessary to capture the result of the `SELECT`. In other words, EdgeDB will do the operation inside the brackets, and then that completed result is given to `places_visited`.
 
-```
+```edgeql
 INSERT Vampire {
   name := 'Count Dracula',
   places_visited := (SELECT Place FILTER .name = 'Romania'),
@@ -77,7 +77,7 @@ The `uuid` there is the reply from the server showing that we were successful (o
 
 Let's check if `places_visited` worked. We only have one `Vampire` object now, so let's `SELECT` it:
 
-```
+```edgeql
 SELECT Vampire {
   places_visited: {
     name
@@ -101,7 +101,7 @@ The `anytype` part is interesting, because that means it can work on types like 
 
 Now let's go back to our constraint for `HumanAge`, which is 120. The `HumanAge` type looks like this:
 
-```
+```sdl
 scalar type HumanAge extending int16 {
   constraint max_value(120);
 }
@@ -109,7 +109,7 @@ scalar type HumanAge extending int16 {
 
 Remember, it's a scalar type because it can only have one value. Then we'll add it to the `NPC` type. 
 
-```
+```sdl
 type NPC extending Person {
   property age -> HumanAge;
 }
@@ -117,7 +117,7 @@ type NPC extending Person {
 
 It's our own type with its own name, but underneath it's an `int16` that can't be greater than 120. So if we write this, it won't work:
 
-```
+```edgeql
 INSERT NPC {
     name := 'The innkeeper',
     age := 130
@@ -136,7 +136,7 @@ This similarity to `SELECT` might make you nervous, because if you type somethin
 
 So let's give it a try. Remember our two `Country` objects for Hungary and Romania? Let's delete them:
 
-```
+```edgeql
 DELETE Country;
 ```
 
@@ -148,19 +148,19 @@ Just like an insert, it gives us the id numbers of the objects that are now dele
 
 Okay, insert them again. Now let's delete with a filter:
 
-```
+```edgeql
 DELETE Country FILTER .name ILIKE '%States%';
 ```
 
 Nothing matches, so the output is `{}` - we deleted nothing. Let's try again:
 
-```
+```edgeql
 DELETE Country FILTER .name ILIKE '%ania%';
 ```
 
 We got a `{Object {id: eaa9b03a-2898-11eb-b5e8-27121e63218a}}`, which is certainly Romania. Only Hungary is left. What if we want to see what we deleted? No problem - just put the `DELETE` inside brackets and `SELECT` it. Let's delete all the `Country` objects again but this time we'll select it:
 
-```
+```edgeql
 SELECT (DELETE Country) {
   name
 };

--- a/chapter4/answers.md
+++ b/chapter4/answers.md
@@ -7,7 +7,7 @@ The keyword to make it work is `DETACHED`, so that we can pull from the `NPC` ty
 ```edgeql
 INSERT NPC {
   name := 'I Love Mina',
-  lover := (SELECT NPC FILTER .name LIKE '%Mina%' LIMIT 1)
+  lover := (SELECT DETACHED NPC FILTER .name LIKE '%Mina%' LIMIT 1)
 };
 ```
 

--- a/chapter4/answers.md
+++ b/chapter4/answers.md
@@ -4,7 +4,7 @@
 
 The keyword to make it work is `DETACHED`, so that we can pull from the `NPC` type in general instead of the `NPC` type we are inserting:
 
-```
+```edgeql
 INSERT NPC {
   name := 'I Love Mina',
   lover := (SELECT NPC FILTER .name LIKE '%Mina%' LIMIT 1)
@@ -13,7 +13,7 @@ INSERT NPC {
 
 One other method that can work is this:
 
-```
+```edgeql
 INSERT NPC {
   name := 'I Love Mina',
   lover := (SELECT Person FILTER .name LIKE '%Mina%' LIMIT 1)
@@ -26,7 +26,7 @@ We changed `SELECT NPC` to `SELECT Person`. Even though `NPC` extends from `Pers
 
 Like this, using `LIKE` and `LIMIT`:
 
-```
+```edgeql
 SELECT Person {
   name
 } FILTER .name LIKE '%a%' LIMIT 2;
@@ -36,7 +36,7 @@ SELECT Person {
 
 Just use `NOT EXISTS`:
 
-```
+```edgeql
 SELECT NPC {name} FILTER NOT EXISTS .places_visited;
 ```
 
@@ -44,20 +44,21 @@ SELECT NPC {name} FILTER NOT EXISTS .places_visited;
 
 Take the original query:
 
-```
+```edgeql
 SELECT has_nine_in_it := <cal::local_time>'09:09:09';
 ```
 
 and use <str> to cast the `cal::local_time` to a string, then add `LIKE '%9%' at the end, like so:
-  
-```
+
+```edgeql
 SELECT has_nine_in_it := <str><cal::local_time>'09:09:09' LIKE '%9%';
 ```
 
 #### 5. Selecting while inserting and adding a property called `age_ten_years_later`
 
 First take the original insert:
-```
+
+```edgeql
 INSERT NPC {
   name := "The Innkeeper's Son",
   age := 10
@@ -66,7 +67,7 @@ INSERT NPC {
 
 then wrap it in parentheses, add a SELECT and remove the `;`
 
-```
+```edgeql
 SELECT(INSERT NPC {
   name := "The Innkeeper's Son",
   age := 10
@@ -75,7 +76,7 @@ SELECT(INSERT NPC {
 
 Now just add the fields like in any other `SELECT`, then add `age_ten_years_later`:
 
-```
+```edgeql
 SELECT(INSERT NPC {
     name := "The Innkeeper's Son",
     age := 10

--- a/chapter4/answers.md
+++ b/chapter4/answers.md
@@ -48,7 +48,7 @@ Take the original query:
 SELECT has_nine_in_it := <cal::local_time>'09:09:09';
 ```
 
-and use <str> to cast the `cal::local_time` to a string, then add `LIKE '%9%' at the end, like so:
+and use `<str>` to cast the `cal::local_time` to a string, then add `LIKE '%9%' at the end, like so:
 
 ```edgeql
 SELECT has_nine_in_it := <str><cal::local_time>'09:09:09' LIKE '%9%';

--- a/chapter4/index.md
+++ b/chapter4/index.md
@@ -232,44 +232,48 @@ Now the output is more meaningful to us: `{Object {date: '22.44.10', hour: '22',
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. This insert is not working.
 
-```
-INSERT NPC {
-  name := 'I Love Mina',
-  lover := (SELECT Person FILTER .name LIKE '%Mina%' LIMIT 1)
-};
-```
+   ```
+   INSERT NPC {
+     name := 'I Love Mina',
+     lover := (SELECT Person FILTER .name LIKE '%Mina%' LIMIT 1)
+   };
+   ```
 
-The error is: `invalid reference to default::NPC: self-referencing INSERTs are not allowed`. What keyword can we use to make this insert work?
+   The error is: `invalid reference to default::NPC: self-referencing INSERTs are not allowed`. What keyword can we use to make this insert work?
 
-Bonus: there is another method we could use too to make it work without the keyword. Can you think of another way?
+   Bonus: there is another method we could use too to make it work without the keyword. Can you think of another way?
 
 2. How would you display up to 2 `Person` types (and their `name` property) whose names include the letter `a`?
 
 3. How would you display all the `Person` types (and their names) that have never visited anywhere?
 
-Hint: all the `Person` types for which `.places_visited` returns `{}`.
+   Hint: all the `Person` types for which `.places_visited` returns `{}`.
 
 4. Imagine that you have the following `cal::local_time` type:
 
-```
-SELECT has_nine_in_it := <cal::local_time>'09:09:09';
-```
+   ```
+   SELECT has_nine_in_it := <cal::local_time>'09:09:09';
+   ```
 
-This displays `{<cal::local_time>'09:09:09'}` but instead you want to display {true} if it has a 9 and {false} otherwise. How could you do that?
+   This displays `{<cal::local_time>'09:09:09'}` but instead you want to display {true} if it has a 9 and {false} otherwise. How could you do that?
 
 5. We are inserting a character called The Innkeeper's Son:
 
-```
-INSERT NPC {
-  name := "The Innkeeper's Son",
-  age := 10
-};
-```
+   ```
+   INSERT NPC {
+     name := "The Innkeeper's Son",
+     age := 10
+   };
+   ```
 
-How would you `SELECT` this insert at the same time to display the `name`, `age`, and `age_ten_years_later` that is made from `age` plus 10?
+   How would you `SELECT` this insert at the same time to display the `name`, `age`, and `age_ten_years_later` that is made from `age` plus 10?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 5: [Jonathan decides to explore the castle a bit. Just to be safe...](../chapter5/index.md)

--- a/chapter4/index.md
+++ b/chapter4/index.md
@@ -239,7 +239,7 @@ Now the output is more meaningful to us: `{Object {date: '22.44.10', hour: '22',
    ```
    INSERT NPC {
      name := 'I Love Mina',
-     lover := (SELECT Person FILTER .name LIKE '%Mina%' LIMIT 1)
+     lover := (SELECT NPC FILTER .name LIKE '%Mina%' LIMIT 1)
    };
    ```
 

--- a/chapter4/index.md
+++ b/chapter4/index.md
@@ -1,6 +1,6 @@
 # Chapter 4 - "What a strange man this Count Dracula is."
 
->Jonathan Harker wakes up late and is alone in the castle. Dracula appears after nightfall and they talk **through the night**. Dracula is making plans to move to London, and Jonathan gives him some advice about buying houses. Jonathan tells Dracula that a big house called Carfax would be a good house to buy. It's very big and quiet. It's close to an asylum for crazy people, but not too close. Dracula likes the idea. He then tells Jonathan not to go into any of the locked rooms in the castle, because it could be dangerous. Jonathan sees that it's almost morning - they talked through the whole night again. Dracula suddenly stands up and says he must go, and leaves the room. Jonathan thinks about **Mina** back in London, who he is going to marry when he returns. He is beginning to feel that there is something wrong with Dracula, and the castle. Seriously, where are the other people?
+> Jonathan Harker wakes up late and is alone in the castle. Dracula appears after nightfall and they talk **through the night**. Dracula is making plans to move to London, and Jonathan gives him some advice about buying houses. Jonathan tells Dracula that a big house called Carfax would be a good house to buy. It's very big and quiet. It's close to an asylum for crazy people, but not too close. Dracula likes the idea. He then tells Jonathan not to go into any of the locked rooms in the castle, because it could be dangerous. Jonathan sees that it's almost morning - they talked through the whole night again. Dracula suddenly stands up and says he must go, and leaves the room. Jonathan thinks about **Mina** back in London, who he is going to marry when he returns. He is beginning to feel that there is something wrong with Dracula, and the castle. Seriously, where are the other people?
 
 First let's create Jonathan's girlfriend, Mina Murray. But we'll also add a new link to the `Person` type in the schema called `lover`:
 
@@ -109,13 +109,11 @@ The part of Romania where Jonathan Harker is has an average sunrise of around 7 
 
 EdgeDB uses two major types for time.
 
--`std::datetime`, which is very precise and always has a timezone. Times in `datetime` use the ISO 8601 standard.
--`cal::local_datetime`, which doesn't worry about timezone.
+-`std::datetime`, which is very precise and always has a timezone. Times in `datetime` use the ISO 8601 standard. -`cal::local_datetime`, which doesn't worry about timezone.
 
 There are two others that are almost the same as `cal::local_datetime`:
 
--`cal::local_time`, when you only need to know the time of day, and
--`cal::local_date`, when you only need to know the month and the day.
+-`cal::local_time`, when you only need to know the time of day, and -`cal::local_date`, when you only need to know the month and the day.
 
 We'll start with `cal::local_time` first.
 
@@ -141,7 +139,7 @@ type Date {
 }
 ```
 
-`.date[0:2]` is an example of ["slicing"](https://www.edgedb.com/docs/edgeql/funcops/array#operator::ARRAYSLICE). [0:2] means start from index 0 (the first index) and stop *before* index 2, which means indexes 0 and 1. This is fine because to cast a `str` to `cal::local_time` you need to write the hour with two numbers (e.g. 09 is okay, but 9 is not).
+`.date[0:2]` is an example of ["slicing"](https://www.edgedb.com/docs/edgeql/funcops/array#operator::ARRAYSLICE). [0:2] means start from index 0 (the first index) and stop _before_ index 2, which means indexes 0 and 1. This is fine because to cast a `str` to `cal::local_time` you need to write the hour with two numbers (e.g. 09 is okay, but 9 is not).
 
 So this won't work:
 
@@ -175,9 +173,9 @@ SELECT Date {
 };
 ```
 
-That gives us a nice output that shows everything, including the hour: 
+That gives us a nice output that shows everything, including the hour:
 
-```{Object {date: '09:55:05', local_time: <cal::local_time>'09:55:05', hour: '09'}}```.
+`{Object {date: '09:55:05', local_time: <cal::local_time>'09:55:05', hour: '09'}}`.
 
 Finally, we can add some logic to the `Date` type to see if vampires are awake or asleep. We could use an `enum` but to be simple, we will just make it a `str`.
 
@@ -195,9 +193,9 @@ So `awake` is calculated like this:
 - First EdgeDB checks to see if the hour is greater than 7 and less than 19 (7 pm). But it's better to compare with a number than a string, so we write `<int16>.hour` instead of `.hour` so it can compare a number to a number.
 - Then it gives us a string saying either 'asleep' or 'awake' depending on that.
 
-Now if we `SELECT` this with all the properties, it will give us this: 
+Now if we `SELECT` this with all the properties, it will give us this:
 
-```Object {date: '09:55:05', local_time: <cal::local_time>'09:55:05', hour: '09', awake: 'asleep'}```
+`Object {date: '09:55:05', local_time: <cal::local_time>'09:55:05', hour: '09', awake: 'asleep'}`
 
 ## SELECT while you INSERT
 

--- a/chapter5/index.md
+++ b/chapter5/index.md
@@ -226,9 +226,11 @@ And for a *really* long output, try typing `DESCRIBE MODULE default` (with `AS S
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. What do you think `SELECT to_datetime(3600);` will return, and why?
 
-Hint: check the function signatures above and see which one EdgeDB will pick when you enter 3600.
+   Hint: check the function signatures above and see which one EdgeDB will pick when you enter 3600.
 
 2. Will `SELECT <int16>9 + 1.06n IS decimal;` work? And if it does, will it return `{true}`?
 
@@ -239,5 +241,7 @@ Hint: check the function signatures above and see which one EdgeDB will pick whe
 5. What's the best way to describe a type if you only want to see how you wrote it?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 6: [One of the women vampires to her sisters: "He is young and strong; there are kisses for us all."](../chapter6/index.md)

--- a/chapter5/index.md
+++ b/chapter5/index.md
@@ -2,19 +2,19 @@
 
 Poor Jonathan is not having much luck. Here's what happens to him in this chapter:
 
->During the day, Jonathan decides to try to explore the castle but too many doors and windows are locked. He doesn't know how to get out, and wishes he could at least send Mina a letter. He pretends that there is no problem, and keeps talking to Dracula during the night. One night he sees Dracula climb out of his window and down the castle wall, like a snake. Now he is very afraid, and knows that Dracula is not human. A few days later he breaks one of the doors and finds another part of the castle. The room is very strange and he feels sleepy. When he opens his eyes, he sees three vampire women next to him. He is attracted to and afraid of them at the same time. He wants to kiss them, but knows that he will die if he does. They come closer, and he can't move...
+> During the day, Jonathan decides to try to explore the castle but too many doors and windows are locked. He doesn't know how to get out, and wishes he could at least send Mina a letter. He pretends that there is no problem, and keeps talking to Dracula during the night. One night he sees Dracula climb out of his window and down the castle wall, like a snake. Now he is very afraid, and knows that Dracula is not human. A few days later he breaks one of the doors and finds another part of the castle. The room is very strange and he feels sleepy. When he opens his eyes, he sees three vampire women next to him. He is attracted to and afraid of them at the same time. He wants to kiss them, but knows that he will die if he does. They come closer, and he can't move...
 
 ## std::datetime
 
 Since Jonathan was thinking of Mina back in London, let's learn about `std::datetime` because it uses time zones. To create a datetime, you can just cast a string in ISO 8601 format with `<datetime>`. That format looks like this:
 
-```YYYY-MM-DDTHH:MM:SSZ```
+`YYYY-MM-DDTHH:MM:SSZ`
 
 And an actual date looks like this.
 
 `'2020-12-06T22:12:10Z'`
 
-The `T` inside there is just a separator, and the `Z` at the end stands for "zero timeline". That means that it is 0 different (offset) from UTC: in other words, it *is* UTC.
+The `T` inside there is just a separator, and the `Z` at the end stands for "zero timeline". That means that it is 0 different (offset) from UTC: in other words, it _is_ UTC.
 
 One other way to get a `datetime` is to use the `to_datetime()` function. [Here is its signature](https://edgedb.com/docs/edgeql/funcops/datetime/#function::std::to_datetime), which shows that there are six ways to make a `datetime` with this function depending on how you want to make it. EdgeDB will know which one of the six you have chosen depending on what input you give it.
 
@@ -63,7 +63,7 @@ std::to_datetime(epochseconds: float64) -> datetime
 std::to_datetime(epochseconds: int64) -> datetime
 ```
 
-The easiest is probably the third if you find ISO 8601 unfamiliar or you have a bunch of separate numbers to make into a date. With this, our game could have a function that generates integers for times that then use `to_datetime()` to get a proper time stamp. 
+The easiest is probably the third if you find ISO 8601 unfamiliar or you have a bunch of separate numbers to make into a date. With this, our game could have a function that generates integers for times that then use `to_datetime()` to get a proper time stamp.
 
 Let's imagine that it's May 12. It's a bright morning at 10:35 in Castle Dracula. The sun is up, Dracula is asleep somewhere, and Jonathan is trying to use the time during the day to escape to send Mina a letter. In Romania the time zone is 'EEST' (Eastern European Summer Time). We'll use `to_datetime()` to generate this. We won't worry about the year, because the story takes place in the same year - we'll just use 2020 for convenience. We type this:
 
@@ -94,7 +94,7 @@ The answer is 5100 seconds: `{5100s}`.
 To make the query easier for us to read, we can also use the `WITH` keyword to create variables. We can then use the variables in `SELECT` below. We'll make one called `jonathan_wants_to_escape` and another called `mina_has_tea`, and subtract one from another to get a `duration`. With variable names it is now a lot clearer what we are trying to do:
 
 ```
-WITH 
+WITH
   jonathan_wants_to_escape := to_datetime(2020, 5, 12, 10, 35, 0, 'EEST'),
   mina_has_tea := to_datetime(2020, 5, 12, 6, 10, 0, 'UTC'),
   SELECT jonathan_wants_to_escape - mina_has_tea;
@@ -172,7 +172,7 @@ error: possibly more than one element returned by an expression for a computable
 
 Our `MinorVampire` type extends `Person`, and so does `Vampire`. Types can continue to extend other types, and they can extend more than one type at the same time. The more you do this, the more annoying it can be to try to combine it all together in your mind. This is where `DESCRIBE` can help, because it shows exactly what any type is made of. There are three ways to do it:
 
-- `DESCRIBE TYPE MinorVampire` - this will give the [DDL (data definition language)](https://www.edgedb.com/docs/edgeql/ddl/index/) description of a type. DDL is a lower level language than SDL, the language we have been using. It is less convenient for schema, but is more explicit and can be useful for quick changes. We won't be learning any DDL in this course but later on you might find it useful sometimes. For example, with it you can quickly create functions without needing to do a migration. And if you understand SDL it will not be hard to pick up some tricks in DDL. 
+- `DESCRIBE TYPE MinorVampire` - this will give the [DDL (data definition language)](https://www.edgedb.com/docs/edgeql/ddl/index/) description of a type. DDL is a lower level language than SDL, the language we have been using. It is less convenient for schema, but is more explicit and can be useful for quick changes. We won't be learning any DDL in this course but later on you might find it useful sometimes. For example, with it you can quickly create functions without needing to do a migration. And if you understand SDL it will not be hard to pick up some tricks in DDL.
 
 Now back to `DESCRIBE TYPE` which gives the results in DDL. Here's what our `Person` type looks like:
 
@@ -220,7 +220,7 @@ The third method is `DESCRIBE TYPE MinorVampire AS TEXT`. This is what we want, 
 
 The parts that say `readonly := true` we don't need to worry about, as they are automatically generated (and we can't touch them). For everything else, we can see that we need a `name` and a `master`, and could add a `lover`, `age` and `places_visited` for these `MinorVampire`s.
 
-And for a *really* long output, try typing `DESCRIBE MODULE default` (with `AS SDL` or `AS TEXT` if you want). You'll get an output showing the whole module we've built so far.
+And for a _really_ long output, try typing `DESCRIBE MODULE default` (with `AS SDL` or `AS TEXT` if you want). You'll get an output showing the whole module we've built so far.
 
 [Here is all our code so far up to Chapter 5.](code.md)
 

--- a/chapter6/answers.md
+++ b/chapter6/answers.md
@@ -1,6 +1,6 @@
 # Chapter 6 Questions and Answers
 
-1. This select is incomplete. How would you complete it so that it says "Pleased to meet you, I'm " and then the NPC's name?
+#### 1. This select is incomplete. How would you complete it so that it says "Pleased to meet you, I'm " and then the NPC's name?
 
 You can do it with concatenation using `++`:
 

--- a/chapter6/answers.md
+++ b/chapter6/answers.md
@@ -27,7 +27,7 @@ You can of course go with `UPDATE NPC` and `SELECT City` if you prefer.
 Also, here is the same thing using `WITH`:
 
 ```
-WITH 
+WITH
   mina := (SELECT NPC FILTER .name = 'Mina Murray'),
   romania := (SELECT Country FILTER .name = 'Romania'),
 UPDATE mina

--- a/chapter6/answers.md
+++ b/chapter6/answers.md
@@ -72,8 +72,8 @@ WITH letters := {'W', 'J', 'C'}
 } FILTER .name LIKE '%' ++ letters ++ '%';
 ```
 
-You need to wrap the SELECT in brackets, cast with <json> and then SELECT that:
- 
+You need to wrap the SELECT in brackets, cast with `<json>` and then SELECT that:
+
 ```
 WITH letters := {'W', 'J', 'C'}
   SELECT <json>(SELECT Person {

--- a/chapter6/index.md
+++ b/chapter6/index.md
@@ -1,6 +1,6 @@
 # Chapter 6 - Still no escape
 
->The women vampires are next to Jonathan and he can't move. Suddenly, Dracula runs into the room and tells the women to leave: "You can have him later, but not tonight!" The women listen to him. Jonathan wakes up in his bed and it feels like a bad dream...but he sees that somebody folded his clothes, and he knows it was not just a dream. The castle has some visitors from Slovakia the next day, so Jonathan has an idea. He writes two letters, one to Mina and one to his boss. He gives the visitors some money and asks them to send the letters. But Dracula finds the letters, and is angry. He burns them in front of Jonathan and tells him not to do that again. Jonathan is still stuck in the castle, and Dracula knows that Jonathan tried to trick him.
+> The women vampires are next to Jonathan and he can't move. Suddenly, Dracula runs into the room and tells the women to leave: "You can have him later, but not tonight!" The women listen to him. Jonathan wakes up in his bed and it feels like a bad dream...but he sees that somebody folded his clothes, and he knows it was not just a dream. The castle has some visitors from Slovakia the next day, so Jonathan has an idea. He writes two letters, one to Mina and one to his boss. He gives the visitors some money and asks them to send the letters. But Dracula finds the letters, and is angry. He burns them in front of Jonathan and tells him not to do that again. Jonathan is still stuck in the castle, and Dracula knows that Jonathan tried to trick him.
 
 ## Filtering on sets when doing an insert
 
@@ -107,7 +107,7 @@ UPDATE Person
 
 One other operator is `++`, which does concatenation (joining together) instead of adding.
 
-You can do simple operations with it like: ```SELECT 'My name is ' ++ 'Jonathan Harker';``` which gives `{'My name is Jonathan Harker'}`. Or you can do more complicated concatenations as long as you continue to join strings to strings:
+You can do simple operations with it like: `SELECT 'My name is ' ++ 'Jonathan Harker';` which gives `{'My name is Jonathan Harker'}`. Or you can do more complicated concatenations as long as you continue to join strings to strings:
 
 ```
 SELECT 'A character from the book: ' ++ (SELECT NPC.name) ++ ', who is not ' ++ (SELECT Vampire.name);
@@ -128,7 +128,7 @@ This prints:
 Let's also change the `Vampire` type to link it to `MinorVampire` from that side instead. You'll remember that Count Dracula is the only real vampire, while the others are of type `MinorVampire`. That means we need a `multi link`:
 
 ```
-type Vampire extending Person {            
+type Vampire extending Person {
   property age -> int16;
   multi link slaves -> MinorVampire;
 }
@@ -201,7 +201,7 @@ This might make you wonder: what if we do want two-way links? There's actually a
 What do we do if we want the same output in json? It couldn't be easier: just cast using `<json>`. Any type in EdgeDB (except `bytes`) can be cast to json this easily:
 
 ```
-SELECT <json>Vampire { 
+SELECT <json>Vampire {
       # <json> is the only difference from the SELECT above
   name,
   slaves: {name}

--- a/chapter6/index.md
+++ b/chapter6/index.md
@@ -244,27 +244,31 @@ The [documentation on JSON](https://www.edgedb.com/docs/datamodel/scalars/json) 
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. This select is incomplete. How would you complete it so that it says "Pleased to meet you, I'm " and then the NPC's name?
 
-```
-SELECT NPC {
-  name,
-  greeting := ## Put the rest here
-};
-```
+   ```
+   SELECT NPC {
+     name,
+     greeting := ## Put the rest here
+   };
+   ```
 
 2. How would you update Mina's `places_visited` to include Romania if she went to Castle Dracula for a visit?
 
 3. With the set `{'W', 'J', 'C'}`, how would you display all the `Person` types with a name that contains any of these capital letters?
 
-Hint: it involves `WITH` and a bit of concatenation.
+   Hint: it involves `WITH` and a bit of concatenation.
 
 4. How would you display this same query as JSON?
 
 5. How would you add ' the Great' to every Person type?
 
-Bonus question: what's a quick way to undo this using string indexing?
+   Bonus question: what's a quick way to undo this using string indexing?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 7: [Jonathan climbs the castle wall to try to get into Count Dracula's room.](../chapter7/index.md)

--- a/chapter7/index.md
+++ b/chapter7/index.md
@@ -50,8 +50,8 @@ With that you can have up to one Jonathan Harker the `PC`, the `NPC`, the `Vampi
 
 Let's also think about our game mechanics a bit. The book says that the doors inside the castle are too tough for Jonathan to open, but Dracula is strong enough to open them all. In a real game it will be more complicated but we can try something simple to mimic this:
 
-- Doors have a strength, and people have strength as well. 
-- If a person has greater strength than the door, then he or she can open it. 
+- Doors have a strength, and people have strength as well.
+- If a person has greater strength than the door, then he or she can open it.
 
 So we'll create a type `Castle` and give it some doors. For now we only want to give it some "strength" numbers, so we'll just make it an `array<int16>`:
 
@@ -86,7 +86,7 @@ Great. We know that Jonathan can't break out of the castle, but let's try to sho
 Fortunately, there is a function called `min()` that gives the minimum value of a set, so we can use that. If his strength is higher than the door with the smallest number, then he can escape. This query looks like it should work, but not quite:
 
 ```
-WITH 
+WITH
   jonathan_strength := (SELECT Person FILTER .name = 'Jonathan Harker').strength,
   castle_doors := (SELECT Castle FILTER .name = 'Castle Dracula').doors,
     SELECT jonathan_strength > min(castle_doors);
@@ -111,7 +111,7 @@ That also means that `SELECT min({[5, 6], [2, 4]});` will give us the output `{[
 Instead, what we want to use is the [array_unpack()](https://edgedb.com/docs/edgeql/funcops/array#function::std::array_unpack) function which takes an array and unpacks it into a set. So we'll use that on `weakest_door`:
 
 ```
-WITH 
+WITH
   jonathan_strength := (SELECT Person FILTER .name = 'Jonathan Harker').strength,
   doors := (SELECT Castle FILTER .name = 'Castle Dracula').doors,
     SELECT jonathan_strength > min(array_unpack(doors));
@@ -119,7 +119,7 @@ WITH
 
 That gives us `{false}`. Perfect! Now we have shown that Jonathan can't open any doors. He will have to climb out the window to escape.
 
-Along with `min()` there is of course `max()`. `len()` and `count()` are also useful: `len()` gives you the length of an object, and `count()` the number of them. Here is an example of `len()` to get the name length of all the `NPC`  types:
+Along with `min()` there is of course `max()`. `len()` and `count()` are also useful: `len()` gives you the length of an object, and `count()` the number of them. Here is an example of `len()` to get the name length of all the `NPC` types:
 
 ```
 SELECT (NPC.name, 'Name length is: ' ++ <str>len(NPC.name));
@@ -193,10 +193,10 @@ SELECT City {
   name,
   population,
   } FILTER
-  .name ILIKE '%' ++ <str>$name ++ '%' 
-  AND 
+  .name ILIKE '%' ++ <str>$name ++ '%'
+  AND
   .population > <int64>$population
-  AND 
+  AND
   <int64>len(.name) > <int64>$length;
 ```
 

--- a/chapter7/index.md
+++ b/chapter7/index.md
@@ -271,6 +271,8 @@ The `UPDATE` keyword that we learned last chapter can also take parameters, so t
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you select each City and the length of its name?
 
 2. How would you select each City and the length of `name` minus the length of `modern_name` if `modern_name` exists, and 0 if `modern_name` does not exist?
@@ -282,5 +284,7 @@ The `UPDATE` keyword that we learned last chapter can also take parameters, so t
 5. How would you select only the `Person` types that have the shortest names?
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 8: [Workers in the city of Varna load fifty boxes into a ship. Dracula is inside one of them.](../chapter8/index.md)

--- a/chapter8/index.md
+++ b/chapter8/index.md
@@ -326,6 +326,8 @@ So hopefully that explanation should help. You can see that you have a lot of ch
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. How would you select all the `Place` types and their names, plus the `door` property if it's a `Castle`?
 
 2. How would you select `Place` types with `city_name` for `name` if it's a `City` and `country_name` for `name` if it's a `Country`?
@@ -336,14 +338,16 @@ So hopefully that explanation should help. You can see that you have a lot of ch
 
 5. What needs to be fixed in this query? Hint: two things definitely need to be fixed, while one more should probably be changed to make it more readable.
 
-```
-SELECT Place {
-  __type__,
-  name
-  [IS Castle]doors
-};
-```
+   ```
+   SELECT Place {
+     __type__,
+     name
+     [IS Castle]doors
+   };
+   ```
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 9: [Time to meet Dr. Seward, Arthur Holmwood, Quincey Morris, and the strange Renfield.](../chapter9/index.md)

--- a/chapter8/index.md
+++ b/chapter8/index.md
@@ -160,11 +160,11 @@ type Townsperson extending Person {
   }
 ```
 
-The number for a `sequence` type will continue to increase by 1 even if you delete other items. For example, if you inserted five `Townsperson` objects, they would have the numbers 1 to 5. Then if you deleted them all and then inserted one more `Townsperson`, this one would have the number 6 (not 1). So this is another possible option for our `Crewman` type. It's very convenient and there is no chance of duplication, but the number increments on its own every time you insert. Well, you *could* create duplicate numbers using `UPDATE` and `SET` (EdgeDB won't stop you there) but even then it would still keep track of the next number when you do the next insert.
+The number for a `sequence` type will continue to increase by 1 even if you delete other items. For example, if you inserted five `Townsperson` objects, they would have the numbers 1 to 5. Then if you deleted them all and then inserted one more `Townsperson`, this one would have the number 6 (not 1). So this is another possible option for our `Crewman` type. It's very convenient and there is no chance of duplication, but the number increments on its own every time you insert. Well, you _could_ create duplicate numbers using `UPDATE` and `SET` (EdgeDB won't stop you there) but even then it would still keep track of the next number when you do the next insert.
 
 ## Using IS to query multiple types
 
-So now we have quite a few types that extend the `Person` type, many with their own properties. The `Crewman` type has a property `number`, while the `NPC` type has a property called `age`. 
+So now we have quite a few types that extend the `Person` type, many with their own properties. The `Crewman` type has a property `number`, while the `NPC` type has a property called `age`.
 
 But this gives us a problem if we want to query them all at the same time. They all extend `Person`, but `Person` doesn't have all of their links and properties. So this query won't work:
 
@@ -176,7 +176,7 @@ SELECT Person {
 };
 ```
 
-The error is `ERROR: InvalidReferenceError: object type 'default::Person' has no link or property 'age'`. 
+The error is `ERROR: InvalidReferenceError: object type 'default::Person' has no link or property 'age'`.
 
 Luckily there is an easy fix for this: we can use `IS` inside square brackets to specify the type. Here's how it works:
 
@@ -211,7 +211,7 @@ This is pretty good, but the output doesn't show us the type for each of them. T
 
 ```
 SELECT Person {
-  __type__: { 
+  __type__: {
     name      # Name of the type inside module default
   },
   name, # Person.name

--- a/chapter9/index.md
+++ b/chapter9/index.md
@@ -281,40 +281,44 @@ But he has some sort of relationship to Dracula, similar to the `MinorVampire` t
 
 ## Time to practice
 
+<!-- quiz-start -->
+
 1. Why doesn't this insert work and how can it be fixed?
 
-```
-FOR castle IN ['Windsor Castle', 'Neuschwanstein', 'Hohenzollern Castle']
-  UNION(
-    INSERT Castle {
-      name := castle
-});
-```
+   ```
+   FOR castle IN ['Windsor Castle', 'Neuschwanstein', 'Hohenzollern Castle']
+     UNION(
+       INSERT Castle {
+         name := castle
+   });
+   ```
 
 2. How would you do the same insert while displaying the castle's name at the same time?
 3. How would you change the `Vampire` type if all vampires needed a minimum strength of 10?
 4. How would you update all the `Person` types to show that they died on September 11, 1887?
 
-Hint: here's the type again:
+   Hint: here's the type again:
 
-```
-  abstract type Person {
-    required property name -> str {
-        constraint exclusive;
-    }
-    property age -> int16;
-    property strength -> int16;
-    multi link places_visited -> Place;
-    multi link lover -> Person;
-    property first_appearance -> cal::local_date;
-    property last_appearance -> cal::local_date;
-  }
-```
+   ```
+     abstract type Person {
+       required property name -> str {
+           constraint exclusive;
+       }
+       property age -> int16;
+       property strength -> int16;
+       multi link places_visited -> Place;
+       multi link lover -> Person;
+       property first_appearance -> cal::local_date;
+       property last_appearance -> cal::local_date;
+     }
+   ```
 
 5. All the `Person` characters that have an `e` or an `a` in their name have been brought back to life. How would you update to do this?
 
-Hint: "bringing back to life" means that `last_appearance` should return `{}`.
+   Hint: "bringing back to life" means that `last_appearance` should return `{}`.
 
 [See the answers here.](answers.md)
+
+<!-- quiz-end -->
 
 Up next in Chapter 10: [Thick fog and a storm hit the city of Whitby.](../chapter10/index.md)

--- a/chapter9/index.md
+++ b/chapter9/index.md
@@ -6,7 +6,7 @@ For this chapter we've gone back in time a few weeks to when the ship left Varna
 
 ## Working with dates some more
 
-It looks like we have some more people to insert. But first, let's think about the ship a little more. Everyone on the ship was killed by Dracula, but we don't want to delete the crew because they are still part of our game. The book tells us that the ship left on the 6th of July, and the last person (the captain) died on the 4th of August (in 1887). 
+It looks like we have some more people to insert. But first, let's think about the ship a little more. Everyone on the ship was killed by Dracula, but we don't want to delete the crew because they are still part of our game. The book tells us that the ship left on the 6th of July, and the last person (the captain) died on the 4th of August (in 1887).
 
 This is a good time to add two new properties to the `Person` type to indicate when a character is present. We'll call them `first_appearance` and `last_appearance`. The name `last_appearance` is a bit better than `death`, because for the game it doesn't matter: we just want to know when characters are there or not.
 
@@ -49,7 +49,7 @@ UPDATE Crewman
   SET {
   first_appearance := cal::to_local_date(1887, 7, 6),
   last_appearance := cal::to_local_date(1887, 7, 16)
-};      
+};
 ```
 
 This will of course depend on our game. Can a `PC` actually visit the ship when it's sailing to England? Will there be missions to try to save the crew before Dracula kills them? If so, then we will need more precise dates. But we're fine with these approximate dates for now.
@@ -235,7 +235,7 @@ type NPC extending Person {
 This is convenient because we can delete `age` from `Vampire` too:
 
 ```
-type Vampire extending Person {    
+type Vampire extending Person {
   # property age -> int16; **Delete this one now**
   multi link slaves -> MinorVampire;
 }
@@ -245,7 +245,7 @@ You can see that a good usage of abstract types and the `overloaded` keyword let
 
 Okay, let's read the rest of the introduction for this chapter. It continues to explain what Lucy is up to:
 
->...She chooses to marry Arthur Holmwood, and says sorry to the other two. The other two men are sad, but fortunately the three men become friends with each other. Dr. Seward is depressed and tries to concentrate on his work. He is a psychiatrist who works in an asylum close to a large mansion called Carfax. Inside the asylum is a strange man named Renfield that Dr. Seward finds most interesting. Renfield is sometimes calm, sometimes completely crazy, and Dr. Seward doesn't know why he changes his mood so quickly. Also, Renfield seems to believe that he can get power from living things by eating them. He's not a vampire, but seems to act similar sometimes.
+> ...She chooses to marry Arthur Holmwood, and says sorry to the other two. The other two men are sad, but fortunately the three men become friends with each other. Dr. Seward is depressed and tries to concentrate on his work. He is a psychiatrist who works in an asylum close to a large mansion called Carfax. Inside the asylum is a strange man named Renfield that Dr. Seward finds most interesting. Renfield is sometimes calm, sometimes completely crazy, and Dr. Seward doesn't know why he changes his mood so quickly. Also, Renfield seems to believe that he can get power from living things by eating them. He's not a vampire, but seems to act similar sometimes.
 
 Oops! Looks like Lucy doesn't have three lovers anymore. Now we'll have to update her to only have Arthur:
 


### PR DESCRIPTION
There's a few changes here:
- Adds `<!-- quiz-start -->` and `<!-- quiz-end -->` comments around the questions in each chapter, so the sphinx build can extract the questions list (anything not in the list gets ignored, to allow the link to the answers to be removed) and interleave them with the answers. I've done this with comment's so it should get ignored by other markdown renderers, in case we want to distribute this book in another format
- Started adding language annotations to the code blocks, for syntax highlighting
- Fix a few cases where casts like `<int16>` were being interpreted as raw html tags
- Fix a mistake in chapter 4 question 1 code examples
- Formatting changes that prettier made (we can drop this one if you want)