### PR TITLE
Move 'Time to practice' titles inside quiz blocks

### DIFF
--- a/chapter1/index.md
+++ b/chapter1/index.md
@@ -381,9 +381,9 @@ Of course, Jonathan Harker has been inserted with a connection to every city in 
 
 [Here is all our code so far up to Chapter 1.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. Entering `SELECT my_name = 'Timothy' != 'Benjamin';` returns an error. Try adding one character to make it return `{true}`.
 2. Try inserting a `City` called Constantinople, but now known as İstanbul.

--- a/chapter10/index.md
+++ b/chapter10/index.md
@@ -423,9 +423,9 @@ With this, the name becomes Johnny plus a number, namely the number of character
 
 [Here is all our code so far up to Chapter 10.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. Try inserting two `NPC` types in one insert with the following `name`, `first_appearance` and `last_appearance` information.
 

--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -203,9 +203,9 @@ And if you take out the filter and just write `SELECT Person` for the function, 
 
 [Here is all our code so far up to Chapter 11.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you write a function called `lucy()` that just returns all the `NPC` types matching the name 'Lucy Westenra'?
 

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -336,9 +336,9 @@ will return `{true}`. (Because Dracula has no lover and the Crewmen have no name
 
 [Here is all our code so far up to Chapter 12.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. Consider these two functions. Will EdgeDB accept the second one?
 

--- a/chapter13/index.md
+++ b/chapter13/index.md
@@ -326,9 +326,9 @@ SELECT (INTROSPECT Ship) {
 
 [Here is all our code so far up to Chapter 13.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you insert an `NPC` named 'Mr. Swales' who has visited the `City` called 'York', the `Country` called 'England', and the `OtherPlace` called 'Whitby Abbey'? Try it in a single insert.
 

--- a/chapter14/index.md
+++ b/chapter14/index.md
@@ -325,9 +325,9 @@ Here is the output:
 
 [Here is all our code so far up to Chapter 14.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you display just the numbers for all the `Person` types? e.g. if there are 20 of them, displaying `1, 2, 3..., 18, 19, 20`.
 

--- a/chapter15/index.md
+++ b/chapter15/index.md
@@ -306,9 +306,9 @@ Beautiful! All the information is right there.
 
 [Here is all our code so far up to Chapter 15.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you create a type called Horse with a `required property name -> str` that can only be 'Horse'?
 

--- a/chapter16/index.md
+++ b/chapter16/index.md
@@ -251,9 +251,9 @@ type City extending Place {
 
 [Here is all our code so far up to Chapter 16.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you split all the `Person` names into two strings if they have two words, and ignore any that don't have exactly two words?
 

--- a/chapter17/index.md
+++ b/chapter17/index.md
@@ -471,9 +471,9 @@ Here's the output:
 
 [Here is all our code so far up to Chapter 17.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you display every NPC's name, strength, name and population of cities visited, and age (displaying 0 if age = `{}`)? Try it on a single line.
 

--- a/chapter18/index.md
+++ b/chapter18/index.md
@@ -318,9 +318,9 @@ Much better!
 
 [Here is all our code so far up to Chapter 18.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. During the time of Dracula, the Goldmark was used in Germany. One Goldmark had 100 Pfennig. How would you make this type?
 

--- a/chapter19/index.md
+++ b/chapter19/index.md
@@ -391,9 +391,9 @@ With the reverse lookup at the end we have another link between `Country` and it
 
 [Here is all our code so far up to Chapter 19.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you display all the `City` names and the names of the `Region` they are in?
 

--- a/chapter2/index.md
+++ b/chapter2/index.md
@@ -192,9 +192,9 @@ returns `{1887}`.
 
 [Here is all our code so far up to Chapter 2.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. Change the following `SELECT` to display `{100}` by casting: `SELECT '99' + '1'`;
 2. Select all the `City` types that start with 'Mu' (case sensitive).

--- a/chapter3/index.md
+++ b/chapter3/index.md
@@ -174,9 +174,9 @@ Finally, let's insert Hungary and Romania again to finish the chapter. We'll lea
 
 [Here is all our code so far up to Chapter 3.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. This query is trying to display every `NPC` along with the `name` plus every `City` type for each `NPC`, but it's giving an error. What is it missing?
 

--- a/chapter4/index.md
+++ b/chapter4/index.md
@@ -240,9 +240,9 @@ Now the output is more meaningful to us: `{Object {date: '22.44.10', hour: '22',
 
 [Here is all our code so far up to Chapter 4.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. This insert is not working.
 

--- a/chapter5/index.md
+++ b/chapter5/index.md
@@ -208,9 +208,9 @@ So if `TYPE` comes after `DESCRIBE` for types and `MODULE` after `DESCRIBE` for 
 
 [Here is all our code so far up to Chapter 5.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. What do you think `SELECT to_datetime(3600);` will return, and why?
 

--- a/chapter6/index.md
+++ b/chapter6/index.md
@@ -241,9 +241,9 @@ The [documentation on JSON](https://www.edgedb.com/docs/datamodel/scalars/json) 
 
 [Here is all our code so far up to Chapter 6.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. This select is incomplete. How would you complete it so that it says "Pleased to meet you, I'm " and then the NPC's name?
 

--- a/chapter7/index.md
+++ b/chapter7/index.md
@@ -273,9 +273,9 @@ The `UPDATE` keyword that we learned last chapter can also take parameters, so t
 
 [Here is all our code so far up to Chapter 7.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you select each City and the length of its name?
 

--- a/chapter8/index.md
+++ b/chapter8/index.md
@@ -327,9 +327,9 @@ So hopefully that explanation should help. You can see that you have a lot of ch
 
 [Here is all our code so far up to Chapter 8.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. How would you select all the `Place` types and their names, plus the `door` property if it's a `Castle`?
 

--- a/chapter9/index.md
+++ b/chapter9/index.md
@@ -321,9 +321,9 @@ But he has some sort of relationship to Dracula, similar to the `MinorVampire` t
 
 [Here is all our code so far up to Chapter 9.](code.md)
 
-## Time to practice
-
 <!-- quiz-start -->
+
+## Time to practice
 
 1. Why doesn't this insert work and how can it be fixed?
 


### PR DESCRIPTION
In the latest design the header for the practice section is rendered separately with custom styling, so the heading in markdown needs to be moved into the quiz block to hide it.