### PR TITLE
Fix overloading example.

### DIFF
--- a/chapter11/code.md
+++ b/chapter11/code.md
@@ -99,7 +99,7 @@ START MIGRATION TO {
   
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
   }
 };

--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -126,7 +126,7 @@ Now let's write a function where we have two characters fight. We will make it a
 ```sdl
 function fight(one: Person, two: Person) -> str
   using (
-    (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+    one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
   );
 ```
 

--- a/chapter12/code.md
+++ b/chapter12/code.md
@@ -99,12 +99,15 @@ START MIGRATION TO {
   
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -51,9 +51,12 @@ Looks like it worked.
 So now let's overload the `fight()` function. Right now it only works for one `Person` vs. another `Person`, but in the book all the characters get together to try to defeat Dracula. We'll need to overload the function so that more than one character can work together to fight. There are a lot of ways to do it, but we'll choose a simple one:
 
 ```sdl
-function fight(names: str, one: int16, two: Person) -> str
+function fight(names: str, one: int16, two: str) -> str
   using (
-    (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+    WITH opponent := assert_single((SELECT Person FILTER .name = two))
+    SELECT
+        names ++ ' win!' IF one > opponent.strength ELSE
+        two ++ ' wins!'
   );
 ```
 
@@ -61,7 +64,7 @@ Note that overloading only works if the function signature is different. Here ar
 
 ```sdl
 fight(one: Person, two: Person) -> str
-fight(names: str, one: int16, two: Person) -> str
+fight(names: str, one: int16, two: str) -> str
 ```
 
 If we tried to overload it with an input of `(Person, Person)`, it wouldn't work because it's the same. That's because EdgeDB uses the input we give it to know which form of the function to use.
@@ -77,9 +80,7 @@ WITH
       (SELECT NPC FILTER .name IN {'Jonathan Harker', 'Renfield'}).strength
     )
   ),
-  dracula := (SELECT Person FILTER .name = 'Count Dracula'),
-
-SELECT fight('Jon and Ren', jon_and_ren_strength, dracula);
+SELECT fight('Jon and Ren', jon_and_ren_strength, 'Count Dracula');
 ```
 
 So did they...
@@ -100,9 +101,7 @@ WITH
       ).strength
     )
   ),
-  dracula := (SELECT Person FILTER .name = 'Count Dracula'),
-
-  SELECT fight('The four people', four_people_strength, dracula);
+SELECT fight('The four people', four_people_strength, 'Count Dracula');
 ```
 
 Much better:
@@ -175,10 +174,10 @@ You can delete a function with the `DROP` keyword and the function signature. Yo
 
 ```sdl
 fight(one: Person, two: Person) -> str
-fight(names: str, one: int16, two: Person) -> str
+fight(names: str, one: int16, two: str) -> str
 ```
 
-You would delete them with `DROP fight(one: Person, two: Person)` and `DROP fight(names: str, one: int16, two: Person)`. The `-> str` part isn't needed.
+You would delete them with `DROP fight(one: Person, two: Person)` and `DROP fight(names: str, one: int16, two: str)`. The `-> str` part isn't needed.
 
 ## More about Cartesian products - the coalescing operator
 

--- a/chapter13/code.md
+++ b/chapter13/code.md
@@ -100,12 +100,15 @@ START MIGRATION TO {
   
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter14/code.md
+++ b/chapter14/code.md
@@ -106,12 +106,15 @@ START MIGRATION TO {
   
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter15/code.md
+++ b/chapter15/code.md
@@ -121,12 +121,15 @@ START MIGRATION TO {
   
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter16/code.md
+++ b/chapter16/code.md
@@ -130,12 +130,15 @@ START MIGRATION TO {
   
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter17/code.md
+++ b/chapter17/code.md
@@ -135,12 +135,15 @@ START MIGRATION TO {
 
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter17/index.md
+++ b/chapter17/index.md
@@ -12,7 +12,7 @@ tags: Aliases, Named Tuples
 
 ## Named tuples
 
-Remember the function `fight()` that we made? It was overloaded to take either `(Person, Person)` or `(str, Person)` as input. Let's give it Dracula and Renfield:
+Remember the function `fight()` that we made? It was overloaded to take either `(Person, Person)` or `(str, int16, str)` as input. Let's give it Dracula and Renfield:
 
 ```edgeql
 WITH
@@ -309,7 +309,8 @@ So let's give this a try. We'll pretend that we are testing out our game engine.
 ```sdl
 function fight(one: Person, two: Person) -> str
   using (
-    SELECT one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
+    one.name ++ ' wins!' IF one.strength > two.strength ELSE
+    two.name ++ ' wins!'
   );
 ```
 
@@ -318,9 +319,9 @@ But for debugging purposes it would be nice to have some more info. Let's create
 ```edgeql
 CREATE FUNCTION fight_2(one: Person, two: Person) -> str
   USING (
-    SELECT one.name ++ ' fights ' ++ two.name ++ '. ' ++ one.name ++ ' wins!'
-      IF one.strength > two.strength
-      ELSE one.name ++ ' fights ' ++ two.name ++ '. ' ++ two.name ++ ' wins!'
+    one.name ++ ' fights ' ++ two.name ++ '. ' ++ one.name ++ ' wins!'
+    IF one.strength > two.strength ELSE
+    one.name ++ ' fights ' ++ two.name ++ '. ' ++ two.name ++ ' wins!'
   );
 ```
 

--- a/chapter18/code.md
+++ b/chapter18/code.md
@@ -177,12 +177,15 @@ START MIGRATION TO {
 
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter19/code.md
+++ b/chapter19/code.md
@@ -195,12 +195,15 @@ START MIGRATION TO {
 
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool

--- a/chapter20/code.md
+++ b/chapter20/code.md
@@ -195,12 +195,15 @@ START MIGRATION TO {
 
     function fight(one: Person, two: Person) -> str
       using (
-        (one.name ++ ' wins!') IF one.strength > two.strength ELSE (two.name ++ ' wins!')
+        one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
       );
 
-    function fight(names: str, one: int16, two: Person) -> str
+    function fight(names: str, one: int16, two: str) -> str
       using (
-        (names ++ ' win!') IF one > two.strength ELSE (two.name ++ ' wins!')
+        WITH opponent := assert_single((SELECT Person FILTER .name = two))
+        SELECT
+            names ++ ' win!' IF one > opponent.strength ELSE
+            two ++ ' wins!'
       );
 
     function visited(person: str, city: str) -> bool


### PR DESCRIPTION
When overloading a function with object types in the signatire, don't
mix object types and scalars.