### PR TITLE
Fix code block syntax highlighting

### DIFF
--- a/chapter10/index.md
+++ b/chapter10/index.md
@@ -135,7 +135,7 @@ So it sends each tuple into the `FOR` loop, filters by the string (which is `dat
 
 Let's finish this section with a final note about casting. We know that we can cast into any scalar type, and this works for tuples of scalar types too. It uses the same format with `<>` except that you put it inside of `<tuple>`, like this:
 
-```
+```edgeql
 WITH london := ('London', 3500000),
 SELECT <tuple<json, int32>>london;
 ```
@@ -148,7 +148,7 @@ That gives us this output:
 
 Here's another example if we need to do some math with floats on London's population:
 
-```
+```edgeql
 WITH london := <tuple<json, float64>>('London', 3500000),
   SELECT (london.0, london.1 / 9);
 ```

--- a/chapter2/index.md
+++ b/chapter2/index.md
@@ -126,7 +126,7 @@ error: operator '+' cannot be applied to operands of type 'std::str' and 'std::i
 
 And to fix it, just use the angle brackets:
 
-```
+```edgeql
 SELECT <int32>'9' + 9;
 ```
 

--- a/chapter4/index.md
+++ b/chapter4/index.md
@@ -101,7 +101,7 @@ This also shows why abstract types are useful. Here we did a quick search on `Pe
 
 We've got a lot of single characters, let's try selecting just one of them:
 
-```
+```edgeql
 SELECT Person {
   name,
   is_single := NOT EXISTS Person.lover,

--- a/chapter5/index.md
+++ b/chapter5/index.md
@@ -72,7 +72,9 @@ The easiest is probably the third if you find ISO 8601 unfamiliar or you have a 
 
 Let's imagine that it's May 12. It's a bright morning at 10:35 in Castle Dracula. The sun is up, Dracula is asleep somewhere, and Jonathan is trying to use the time during the day to escape to send Mina a letter. In Romania the time zone is 'EEST' (Eastern European Summer Time). We'll use `to_datetime()` to generate this. We won't worry about the year, because the story takes place in the same year - we'll just use 2020 for convenience. We type this:
 
-`SELECT to_datetime(2020, 5, 12, 10, 35, 0, 'EEST');`
+```edgeql
+SELECT to_datetime(2020, 5, 12, 10, 35, 0, 'EEST');
+```
 
 And get the following output:
 

--- a/chapter6/index.md
+++ b/chapter6/index.md
@@ -144,7 +144,7 @@ Then we can `INSERT` the `MinorVampire` type at the same time as we insert the i
 - When we declare a `Vampire` it has `slaves`, but if there are no `MinorVampire`s yet then it will be empty: {}. And if we declare the `MinorVampire` type first it has a `master`, but if we declare them first then their `master` (a `required link`) will not be there.
 - If both types link to each other, we won't be able to delete them if we need to. The error looks something like this:
 
-```
+```edgeql-repl
 edgedb> DELETE MinorVampire;
 ERROR: ConstraintViolationError: deletion of default::MinorVampire (ee6ca100-006f-11ec-93a9-4b5d85e60114) is prohibited by link target policy
   Detail: Object is still referenced in link slave of default::Vampire (e5ef5bc6-006f-11ec-93a9-77e907d251d6).


### PR DESCRIPTION
There is no syntax highlighting, and no «Copy» button. Because the language of the code block is not specified.

<img width="1103" alt="Снимок экрана 2022-02-23 в 17 55 34" src="https://user-images.githubusercontent.com/5902508/155344403-b7f8611e-4b08-46a6-aee4-7549fca8f349.png">
