### PR TITLE
Add overloaded keyword to avoid migration error

### DIFF
--- a/chapter3/index.md
+++ b/chapter3/index.md
@@ -21,7 +21,7 @@ abstract type Person {
 
 `int16` means a 16 bit (2 byte) integer, which has enough space for -32768 to +32767. That's enough for age, so we don't need the bigger `int32` or `int64` types which are much larger. We also don't want it to be a `required property`, because we don't care about everybody's age.
 
-But we don't want `PC`s and `NPC`s to live up to 32767 years, so let's give `age` only to `Vampire` now and think about the other types later. We'll make `Vampire` a type that extends `Person`, and adds age:
+But we don't want `PC`s and `NPC`s to live up to 32767 years, so let's remove `age` from the abstract `Person` type and give it only to `Vampire` now. We will think about the other types later. We'll make `Vampire` a type that extends `Person`, and adds age:
 
 ```sdl
 type Vampire extending Person {


### PR DESCRIPTION
The third chapter has the following code:

```sdl
abstract type Person {
    required property name -> str;
    multi link places_visited -> Place;
    property age -> int16;
  }

type Vampire extending Person {
    property age -> int16; # Missing overloaded 
  }
```

However, this raises the following error during migration:

```
error: property 'age' of object type 'default::Vampire' must be declared using the `overloaded` keyword because it is defined in the following ancestor(s): default::Person
   ┌─ ./dbschema/default.esdl:29:5
   │
29 │     property age -> int16;
   │     ^^^^^^^^^^^^^^^^^^^^^^ error

edgedb error: cannot proceed until .esdl files are fixed

```

There's another instance of the same error:

```sdl
type NPC extending Person {
    annotation description := "Non playable character.";
    property age -> HumanAge; # We'll need to add overloaded here as well.
  }
```


The fix is quite simple. Just adding `overloaded` keyword before `age` in the `Vampire` type solves this. 