### PR TITLE
Fix broken functions

### DIFF
--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -1,5 +1,5 @@
 ---
-tags: Writing Functions, Multiplication
+tags: Writing Functions, Multiplication, Coalescing
 ---
 
 # Chapter 11 - What's wrong with Lucy?
@@ -126,11 +126,53 @@ Now let's write a function where we have two characters fight. We will make it a
 ```sdl
 function fight(one: Person, two: Person) -> str
   using (
-    one.name ++ ' wins!' IF one.strength > two.strength ELSE two.name ++ ' wins!'
+    one.name ++ ' wins!'
+    IF one.strength > two.strength
+    ELSE two.name ++ ' wins!'
   );
 ```
 
-So far only Jonathan and Renfield have the property `strength`, so let's put them up against each other:
+The function _looks_ good, but when you try to create it, you'll get an error:
+
+```
+InvalidFunctionDefinitionError: return cardinality mismatch in function
+  declared to return exactly one value
+```
+
+This happens because `name` and `strength` are not required on our `Person` type. If we pass this function at least one `Person` without a value for one of these properties, the function will return an empty set. (More on that in the next chapter.) EdgeDB doesn't like this because we've told it in the function definition that the function will return a string.
+
+We could go back and require the `name` and `strength` properties. We'd need to make sure all of our `Person` objects have values for each of them. That's a lot of hassle, and it's not something we're ready to do right now.
+
+## Providing fallbacks with the coalescing operator
+
+The easiest way to fix our function would be to provide some sort of fallback for the properties that might not be set. If `one` doesn't have a name, we could just refer to them as `Fighter 1`. If someone doesn't have a strength, we could just default their strength to `0`.
+
+To do that we can use the {eql:op}`coalescing operator <docs:coalesce>`, which is written `??`. It evaluates to whatever is on the left if that's not empty. Otherwise, it evaluates to whatever is on the right.
+
+Here is a quick example:
+
+```edgeql-repl
+edgedb> SELECT <str>{} ?? 'Count Dracula is now in Whitby';
+```
+
+The empty set is on the left, but since it _is_ the empty set, it doesn't get the nod from the coalescing operator. Instead, this query will produce the string to the right of the coalescing operator: `{'Count Dracula is now in Whitby'}`
+
+If neither side of the operator is the empty set, the coalescing operator will produce whatever is on the left. If _both_ sides are the empty set, it will produce the empty set.
+
+Here's how we can use the coalescing operator to fix our function:
+
+```sdl
+function fight(one: Person, two: Person) -> str
+  using (
+    (one.name ?? 'Fighter 1') ++ ' wins!'
+    IF (one.strength ?? 0) > (two.strength ?? 0)
+    ELSE (two.name ?? 'Fighter 2') ++ ' wins!'
+  );
+```
+
+Now, EdgeDB has fallbacks in the event one of those values is an empty set. If `one.name` is the empty set, we get `'Fighter 1'`. If one of the `strength` properties is the empty set, we get `0`. If `two.name` is the empty set, we get `'Fighter 2`. This ensures that the function can always return the string response we promised.
+
+So far only Jonathan and Renfield have the property `strength`, so let's put them up against each other in this new `fight` function:
 
 ```edgeql
 WITH

--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -141,7 +141,7 @@ InvalidFunctionDefinitionError: return cardinality mismatch in function
 
 This happens because `name` and `strength` are not required on our `Person` type. If we pass this function at least one `Person` without a value for one of these properties, the function will return an empty set. (More on that in the next chapter.) EdgeDB doesn't like this because we've told it in the function definition that the function will return a string.
 
-We could go back and require the `name` and `strength` properties. We'd need to make sure all of our `Person` objects have values for each of them. That's a lot of hassle, and it's not something we're ready to do right now.
+We could go back and require the `name` and `strength` properties. We'd need to make sure all of our `Person` objects have values for each of them. That's a lot of trouble, and it's not something we're ready to do right now.
 
 ## Providing fallbacks with the coalescing operator
 

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -190,7 +190,7 @@ WITH b_places := (SELECT Place FILTER Place.name ILIKE 'b%'),
 SELECT b_places.name ++ ' ' ++ f_places.name;
 ```
 
-The output is... maybe unexpected if you didn't fully comprehend the previous paragraph.
+The result may not be what you'd expect.
 
 ```
 {}

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -62,11 +62,12 @@ function fight(people_names: array<str>, opponent: Person) -> str
   );
 ```
 
-With this overload, we accept two arguments: an array of the names of the fighters and a `Person` object that is their opponent. You're seeing some new standard library functions in use here that we'll dig into more later. For now, here are the basics you need to know:
+With this overload, we accept two arguments: an array of the names of the fighters and a `Person` object that is their opponent. You're seeing a couple of new standard library functions in use here that we'll dig into more later. For now, here are the basics you need to know:
 
-- We need to call `array_unpack` when we assign the value to `people` in our `WITH`. This converts our array to a set which is needed because `IN` only works with a set.
-- At the beginning of our `SELECT`, we call `array_join` on `people_names` so that this is displayed as a string. In order to use the coalescing operator (`??`), both operands must be of the same type. Since our alternative is the string `"Fighters"`, we need this side to be a string as well.
+- We call `contains`, passing our array of names and the `.name` property. This allows us to filter only `Person` objects with a `.name` that matches one of those in the array.
 - `sum` in the next line of our `SELECT` takes all the values in a set and adds them together. That gives us a total strength of the fighters to compare against their opponent's strength.
+
+You may wonder why we provide a default value for the opponent name (`opponent.name ?? 'Opponent'`) but not for the names of the people in the group. This is because, if the array of names is empty, the group cannot win since no `Person` object will be returned from the query. We can't have a case where `people_names` is empty but the party won the fight, so no need for a fallback name to call the group! The `.name` property isn't required though, so since you pass in the opponent's `Person` object directly, you could pass in a powerful opponent without a name. The group is selected by their names, so there's no way to do the same for their side.
 
 Note that overloading only works if the function signature is different. Here are the two signatures we have now for comparison:
 

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -54,10 +54,10 @@ So now let's overload the `fight()` function. Right now it only works for one `P
 function fight(people_names: array<str>, opponent: Person) -> str
   using (
     WITH
-        people := (SELECT Person FILTER .name IN array_unpack(people_names)),
+        people := (SELECT Person FILTER contains(people_names, .name)),
     SELECT
-        (array_join(people_names, ', ') ?? 'Fighters') ++ ' win!'
-        IF (sum(people.strength) ?? 0) > (opponent.strength ?? 0)
+        array_join(people_names, ', ') ++ ' win!'
+        IF sum(people.strength) > (opponent.strength ?? 0)
         ELSE (opponent.name ?? 'Opponent') ++ ' wins!'
   );
 ```


### PR DESCRIPTION
These functions no longer work. When you try to create them, you run into an error: `InvalidFunctionDefinitionError: return cardinality mismatch in function declared to return exactly one value`. This fixes them by using the coalescing operator to provide fallbacks to optional properties.

I have almost 7,000 words of notes on this book that I'd like to use for a more extensive refactor at some point, but this takes care of the most pressing issue I found during my review. I'll circle back to the rest later.