### PR TITLE
`multi link` used before introduction

### DIFF
--- a/chapter1/index.md
+++ b/chapter1/index.md
@@ -80,7 +80,7 @@ START MIGRATION TO {
   module default {
     type Person {
       required property name -> str;
-      multi link places_visited -> City;
+      property places_visited -> array<str>;
     }
 
     type City {


### PR DESCRIPTION
`multi link` is introduced later in the text and until that the text even refers to the `array<str>` type for `places_visited`.