### PR TITLE
Remove edgeql-repl annotation

### DIFF
--- a/chapter1/index.md
+++ b/chapter1/index.md
@@ -160,7 +160,7 @@ l or list - list the DDL statements associated with prompt
 
 Sure, let's be curious and try typing `l` to see what commands will be generated to create our `City` type. If we type `l` we will see the following:
 
-```edgeql-repl
+```
 Did you create object type 'default::City'? [y,n,l,c,b,s,q,?]
 > l
 The following DDL statements will be applied:
@@ -199,7 +199,8 @@ Did you create object type 'default::City'? [y,n,l,c,b,s,q,?]
 > y
 Did you alter object type 'default::NPC'? [y,n,l,c,b,s,q,?]
 > y
-Please specify an expression to populate existing objects in order to make property 'name' of object type 'default::NPC' required:
+Please specify an expression to populate existing objects in order to make
+property 'name' of object type 'default::NPC' required:
 fill_expr>
 ```
 
@@ -300,14 +301,14 @@ EdgeDB also has a byte literal type that gives you the bytes of a string. This i
 
 You create byte literals by adding a `b` in front of the string:
 
-```edgeql-repl
+```
 db> select b'Bistritz';
 {b'Bistritz'}
 ```
 
 And because the characters must be 1 byte, only ASCII works for this type. So the name in `modern_name` as a byte literal will generate an error because of the `ț`:
 
-```edgeql-repl
+```
 db> select b'Bistrița';
 error: EdgeQLSyntaxError: invalid bytes literal: character 'ț' is unexpected, only ascii chars are allowed in bytes literals
   ┌─ <query>:1:8

--- a/chapter10/index.md
+++ b/chapter10/index.md
@@ -190,7 +190,7 @@ Now we get `{230023}`, the population of Munich.
 
 You can still access items inside tuples by numbers even if they have a name:
 
-```edgeql-repl
+```
 db> select (name := 'Jonathan Harker', age := 25).0;
 {'Jonathan Harker'}
 db> select (name := 'Jonathan Harker', age := 25).name;

--- a/chapter11/answers.md
+++ b/chapter11/answers.md
@@ -108,7 +108,7 @@ function two_cities(city_one: str, city_two: str) -> float64
 
 Then it would be used in this sort of way:
 
-```edgeql-repl
+```
 db> select two_cities('Munich', 'Bistritz');
 {25.277252747252746}
 db> select two_cities('Munich', 'London');

--- a/chapter11/index.md
+++ b/chapter11/index.md
@@ -173,7 +173,7 @@ To do that we can use the {eql:op}`coalescing operator <docs:coalesce>`, which i
 
 Here is a quick example:
 
-```edgeql-repl
+```
 db> select <str>{} ?? 'Count Dracula is now in Whitby';
 ```
 
@@ -266,7 +266,7 @@ Here is the output. It's a total of nine fights, where each person in Set 1 figh
 
 And if you take out the filter and just write `select Person` for the function, you will get well over 100 results. EdgeDB by default will only show the first 100, eventually displaying this after the first 100 results:
 
-```edgeql-repl
+```
 # First 98 results...
 'Count Dracula wins!',
 'Fighter 2 wins!',

--- a/chapter12/index.md
+++ b/chapter12/index.md
@@ -160,7 +160,7 @@ function visited(person: str, city: str) -> bool
 
 Pretty simple! Let's add it to the schema and do a migration. Now our queries are much shorter:
 
-```edgeql-repl
+```
 db> select visited('Mina Murray', 'London');
 {true}
 db> select visited('Mina Murray', 'Bistritz');
@@ -220,7 +220,7 @@ You can probably guess that the same is true for array constructors too, so `sel
 
 Okay, one more time, this time making sure that the `{}` empty set is of type `str`:
 
-```edgeql-repl
+```
 db> select {'Buda-Pesth', 'Bistritz'} ++ <str>{};
 {}
 ```

--- a/chapter13/index.md
+++ b/chapter13/index.md
@@ -415,7 +415,7 @@ And now let's play around with this sequence type a bit before we make a `PCNumb
 
 In other words, just typing `sequence_next()` won't work because EdgeDB doesn't know which sequence type we want to increment:
 
-```edgeql-repl
+```
 db> select sequence_next();
 error: QueryError: function "sequence_next()" does not exist
   ┌─ <query>:1:8
@@ -426,7 +426,7 @@ error: QueryError: function "sequence_next()" does not exist
 
 And typing `SomeSequenceNumber` won't work either because SomeSequenceNumber isn't an object type in our schema:
 
-```edgeql-repl
+```
 db> select sequence_next(SomeSequenceNumber);
 error: InvalidReferenceError: object type or alias 'default::SomeSequenceNumber' does not exist
   ┌─ <query>:1:22
@@ -437,7 +437,7 @@ error: InvalidReferenceError: object type or alias 'default::SomeSequenceNumber'
 
 But did you notice that the function is expecting an argument of `ScalarType`? We saw this just above when we learned the `introspect` keyword. Let's try replacing `SomeSequenceNumber` with `introspect SomeSequenceNumber` which returns a `ScalarType`:
 
-```edgeql-repl
+```
 db> select sequence_next(introspect SomeSequenceNumber);
 {1}
 ```
@@ -446,7 +446,7 @@ Success! Just add `introspect` and the `sequence_next()` and `sequence_reset()` 
 
 Let's play around with this sequence number of ours for a bit. As you can see, it can be incremented or reset, but can't be reset to anything less than 1.
 
-```edgeql-repl
+```
 db> select sequence_next(introspect SomeSequenceNumber);
 {2}
 db> select sequence_next(introspect SomeSequenceNumber);

--- a/chapter14/index.md
+++ b/chapter14/index.md
@@ -444,7 +444,7 @@ In this case, we are asking EdgeDB to show us each and every object that is link
 
 You can see that Romania has been visited by a `Vampire` object (that's Dracula) and an `NPC` object (that's Jonathan Harker), while Munich has been visited by a `PC` object (Emil Sinclair) and an `NPC` object (Jonthan Harker again). So if we don't specify with `[is Vampire]` or `[is NPC]` then it will just return each and every object connected via a link called `places_visited`. This is fine, but it limits the shapes that we can make in the query. For example, there is no guarantee that any linking object will have the property `name` so this query won't work:
 
-```edgeql-repl
+```
 db> select Place {
 .......  name,
 .......  visitors := .<places_visited {name}

--- a/chapter16/index.md
+++ b/chapter16/index.md
@@ -128,7 +128,7 @@ You can see that `description` is a short string that we write, while `excerpt` 
 
 The {ref}`functions for strings <docs:ref_std_string>` can be particularly useful when doing queries on our `BookExcerpt` type (or `BookExcerpt` via `Event`). One is called {eql:func}`docs:std::str_lower` and makes strings lowercase:
 
-```edgeql-repl
+```
 db> select str_lower('RENFIELD WAS HERE');
 {'renfield was here'}
 ```
@@ -191,7 +191,7 @@ Some other functions for strings are:
 
 - `str_split()` lets you make an array from a string, split however you like. Most common is to split by `' '` to separate words:
 
-```edgeql-repl
+```
 db> select str_split('Oh, hear me! hear me! Let me go! let me go! let me go!', ' ');
 {
   [
@@ -252,7 +252,7 @@ The output is an array of the text split by line:
 
 - Two functions called `re_match()` (for the first match) and `re_match_all()` (for all matches) if you know how to use [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) (regexes) and want to use those. This could be useful because the book Dracula was written over 100 years ago and has different spelling sometimes. The word `tonight` for example is always written with the older `to-night` spelling in Dracula. We can use these functions to take care of that:
 
-```edgeql-repl
+```
 db> select re_match_all('[Tt]o-?night', 'Dracula is an old book,
 so the word tonight is written to-night.
 Tonight we know how to write both tonight and to-night.');
@@ -270,14 +270,14 @@ Here is the output: `{['tonight'], ['to-night'], ['Tonight'], ['tonight'], ['to-
 
 And to match anything, you can use the wildcard character: `.`
 
-```edgeql-repl
+```
 db> select re_match_all('.oo.', 'Noo, Lord Dracula, why did you lock the door?');
 {['Noo,'], ['door']}
 ```
 
 The `.` wildcard operator still determines the length of the slice of the string to match on, so you can use more of them to lengthen the part of the string in which we are looking for a match.
 
-```edgeql-repl
+```
 db> select re_match_all('.h...oo..', 'Noo, Lord Dracula, why did you lock the door?');
 {['the door?']}
 ```

--- a/chapter17/index.md
+++ b/chapter17/index.md
@@ -157,7 +157,7 @@ function can_enter(person_name: str, place: str) -> optional str
 
 And now let's do a migration. One of the migration questions will ask us what default name to give the existing objects, because `name` is a required property. We can just type `''` to give an empty string by default.
 
-```edgeql-repl
+```
 Please specify an expression to populate existing objects in order to make property 'name' of object type 'default::HasNameAndCoffins' required:
 fill_expr_2> ''
 ```
@@ -175,7 +175,7 @@ set {
 
 Now let's give the ship `The Demeter` some coffins.
 
-```edgeql-repl
+```
 db> update HasNameAndCoffins filter .name = <str>$place_name
 ....... set {
 .......   coffins := .coffins + <int16>$number
@@ -186,7 +186,7 @@ Parameter <int16>$number: 10
 
 Castle Dracula naturally should have some coffins too. Let's go with 50.
 
-```edgeql-repl
+```
 db> update HasNameAndCoffins filter .name = <str>$place_name
 ....... set {
 .......   coffins := .coffins + <int16>$number
@@ -270,7 +270,7 @@ error: cannot insert into expression alias 'default::CrewmanInBulgaria'
 
 So all inserts are still done through the `Crewman` type. But because an alias is a subtype and a shape, we can select it in the same way as anything else. Let's now compare a `select` on the `Crewman` objects to a `select` with the `CrewmanInBulgaria` alias:
 
-```edgeql-repl
+```
 db> select Crewman { name, strength };
 {
   default::Crewman {name: 'Crewman 1', strength: 1},

--- a/chapter20/index.md
+++ b/chapter20/index.md
@@ -101,7 +101,7 @@ For `first_appearance` and `last_appearance` we use {eql:type}`docs:cal::local_d
 
 So for databases with users around the world, `datetime` is usually the best choice. Then you can use a function like {eql:func}`docs:std::to_datetime` to turn five `int64`s, one `float64` (for the seconds) and one `str` (for [the timezone](https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations)) into a `datetime` that is always returned as UTC:
 
-```edgeql-repl
+```
 db> select std::to_datetime(2020, 10, 12, 15, 35, 5.5, 'KST');
 ....... # October 12 2020, 3:35 pm and 5.5 seconds in Korea (KST = Korean Standard Time)
 {<datetime>'2020-10-12T06:35:05.500Z'} # The return value is UTC, 6:35 (plus 5.5 seconds) in the morning
@@ -456,7 +456,7 @@ You can think of the syntax as a helpful guide to keep your declarations in the 
 
 We have only seen DDL in our `.edgeql` files that are automatically generated every time a migration takes place. DDL used to be used sometimes in the past, and was even mentioned in the first edition of this book. But with better and better migration tools, there is little need for it. And in fact, EdgeDB is set by default to disallow DDL. Take this attempt to use DDL for example and the error output it generates:
 
-```edgeql-repl
+```
 db> create function hi() -> str using ("Hi");
 error: QueryError: bare DDL statements are not allowed in this database
   ┌─ <query>:1:1

--- a/chapter3/index.md
+++ b/chapter3/index.md
@@ -309,7 +309,7 @@ select City {
 
 If the splat operator is used for a type that is extended by other types, it will choose all of the properties that they have in common. Let's demonstrate that with three queries.
 
-```edgeql-repl
+```
 db> select PC{*};
 {default::PC {name: 'Emil Sinclair', id: 8b0633d2-0b04-11ee-bd1f-2f48cb19fb35, class: Mystic}}
 db> select NPC {*};

--- a/chapter5/index.md
+++ b/chapter5/index.md
@@ -27,7 +27,7 @@ One other way to get a `datetime` is to use the `to_datetime()` function. {eql:f
 
 Let's do a quick detour before getting back to datetime. Inside the `to_datetime()` function you'll notice one unfamiliar type inside called a {eql:type}` ``decimal`` <docs:std::decimal>` type. A decimal is a float with "arbitrary precision", meaning that you can give it as many numbers after the decimal point as you want. This is because float types on computers [become imprecise after a while](https://www.youtube.com/watch?v=PZRI1IfStY0&ab_channel=Computerphile) thanks to rounding errors. This example shows it:
 
-```edgeql-repl
+```
 db> select 6.777777777777777; # Good so far
 {6.777777777777777}
 db> select 6.7777777777777777; # Add one more digit...
@@ -36,7 +36,7 @@ db> select 6.7777777777777777; # Add one more digit...
 
 If you want to avoid this, add an `n` to the end to get a `decimal` type which will be as precise as it needs to be.
 
-```edgeql-repl
+```
 db> select 6.7777777777777777n;
 {6.7777777777777777n}
 db> select 6.7777777777777777777777777777777777777777777777777n;
@@ -45,7 +45,7 @@ db> select 6.7777777777777777777777777777777777777777777777777n;
 
 Similarly, there is a `bigint` type that also uses `n` for an arbitrary size. That's because even int64 has a limit: it's 9223372036854775807.
 
-```edgeql-repl
+```
 db> select 9223372036854775807; # Good so far...
 {9223372036854775807}
 db> select 9223372036854775808; # But add 1 and it will fail
@@ -54,7 +54,7 @@ edgedb error: NumericOutOfRangeError: std::int64 out of range
 
 Here as well you can just add an `n` and it will create a `bigint` that can accommodate any size.
 
-```edgeql-repl
+```
 db> select 9223372036854775808n;
 {9223372036854775808n}
 ```

--- a/chapter6/index.md
+++ b/chapter6/index.md
@@ -253,7 +253,7 @@ Then we can `insert` the `MinorVampire` type at the same time as we insert the i
 - When we declare a `Vampire` it has `slaves`, but if there are no `MinorVampire`s yet then it will be empty: {}. And if we declare the `MinorVampire` type first it has a `master`, but if we declare them first then their `master` (a `required` link) will not be there.
 - If both types link to each other, we won't be able to delete them if we need to. The error looks something like this:
 
-```edgeql-repl
+```
 db> delete MinorVampire;
   ERROR: ConstraintViolationError: deletion of default::MinorVampire
   (ee6ca100-006f-11ec-93a9-4b5d85e60114) is prohibited by link target policy

--- a/chapter7/index.md
+++ b/chapter7/index.md
@@ -276,7 +276,7 @@ So that will give all `City` type objects with "b" in the name and that have a d
 
 Parameters work just as well in inserts too. Here's a `Time` insert that prompts the user for the hour, minute, and second:
 
-```edgeql-repl
+```
 with time := (
    insert Time {
      clock := <str>$hour ++ <str>$minute ++ <str>$second

--- a/chapter9/index.md
+++ b/chapter9/index.md
@@ -113,7 +113,7 @@ type NPC extending Person {
 
 Two convenient functions are {eql:func}` ``datetime_current()`` <docs:std::datetime_current>` and {eql:func}` ``datetime_of_statement()`` <docs:std::datetime_of_statement>`, which give the datetime right now. Let's try the first one out:
 
-```edgeql-repl
+```
 db> select datetime_current();
 {<datetime>'2023-05-28T10:18:56.889701Z'}
 ```
@@ -124,7 +124,7 @@ Note though that `datetime_current()` will not return the exact same date as ano
 
 We can see this in the following example in which we create three datetimes and then picks the most recent one using the `max()` function. Note that the third datetime created - the most recent - is the one returned by `max()`.
 
-```edgeql-repl
+```
 db> with three_dates := {
   datetime_current(),
   datetime_current(),
@@ -141,7 +141,7 @@ select three_dates union max(three_dates);
 
 However, if we change the function to `datetime_of_statement()`, then the exact same datetime will be returned no matter how many times we call it:
 
-```edgeql-repl
+```
 edgedb> select {datetime_of_statement(), datetime_of_statement(), datetime_of_statement()};
 {
   <datetime>'2023-06-18T08:34:10.621754Z',

--- a/translations/zh/chapter1/index.md
+++ b/translations/zh/chapter1/index.md
@@ -197,14 +197,14 @@ EdgeDB 还有一种字节字面量类型，可以用来创建用字符串表示�
 
 你可以通过在字符串前添加一个 `b` 来创建一个字节文字：
 
-```edgeql-repl
+```
 db> select b'Bistritz';
 {b'Bistritz'}
 ```
 
 因为每个字符必须是 1 个字节，因此只有 ASCII 才适用于这种类型。所以如果 `modern_name` 是字节类型且名字中有类似 `ț` 这样的字符，将会产生错误：
 
-```edgeql-repl
+```
 db> select b'Bistrița';
 error: invalid bytes literal: character 'ț' is unexpected, only ascii chars are allowed in bytes literals
   ┌─ query:1:8

--- a/translations/zh/chapter11/answers.md
+++ b/translations/zh/chapter11/answers.md
@@ -108,7 +108,7 @@ function two_cities(city_one: str, city_two: str) -> float64
 
 然后我们会像下面一样使用它：
 
-```edgeql-repl
+```
 db> select two_cities('Munich', 'Bistritz');
 {25.277252747252746}
 db> select two_cities('Munich', 'London');

--- a/translations/zh/chapter11/index.md
+++ b/translations/zh/chapter11/index.md
@@ -165,7 +165,7 @@ InvalidFunctionDefinitionError: return cardinality mismatch in function
 
 下面是一个简单的例子：
 
-```edgeql-repl
+```
 db> select <str>{} ?? 'Count Dracula is now in Whitby';
 ```
 

--- a/translations/zh/chapter12/index.md
+++ b/translations/zh/chapter12/index.md
@@ -128,7 +128,7 @@ function visited(person: str, city: str) -> bool
 
 现在，我们的查询变得方便得多了：
 
-```edgeql-repl
+```
 db> select visited('Mina Murray', 'London');
 {true}
 db> select visited('Mina Murray', 'Bistritz');
@@ -217,7 +217,7 @@ error: operator '++' cannot be applied to operands of type 'std::str' and 'anyty
 
 好的，让我们再试一次，这次确保 `{}` 空集是 `str` 类型：
 
-```edgeql-repl
+```
 db> select {'Buda-Pesth', 'Bistritz'} ++ <str>{};
 {}
 ```

--- a/translations/zh/chapter16/index.md
+++ b/translations/zh/chapter16/index.md
@@ -116,7 +116,7 @@ type Event {
 
 {ref}`字符串函数 <docs:ref_std_string>` 在对我们的 `BookExcerpt` 类型（或通过 `Event` 的 `BookExcerpt`）进行查询时特别有用。其中一个实用的函数是 {eql:func}`docs:std::str_lower`，它可以使字符串的字母都变为小写：
 
-```edgeql-repl
+```
 db> select str_lower('RENFIELD WAS HERE');
 {'renfield was here'}
 ```
@@ -165,7 +165,7 @@ select BookExcerpt {
 
 - `str_split()`：该函数可以将字符串以你想要的方式进行拆分并转变为数组。最常见的是用 `' '` 作为分割符来分隔单词：
 
-```edgeql-repl
+```
 db> select str_split('Oh, hear me! hear me! Let me go! let me go! let me go!', ' ');
 {
   [
@@ -224,7 +224,7 @@ let me go!', '\n');
 
 - `re_match()`（用于第一次匹配）和 `re_match_all()]`（用于所有匹配）：如果你对如何使用 [正则表达式](https://en.wikipedia.org/wiki/Regular_expression) 有所了解，并想使用它们，这俩函数可能会很有用。小说《德古拉》写于 100 多年前，因此有些单词的拼写已经不大一样了。例如，`tonight` 这个词在《德古拉》中总是使用较旧的 `to-night` 拼写。为了处理这样的问题，我们就可以使用这两个函数：
 
-```edgeql-repl
+```
 db> select re_match_all('[Tt]o-?night', 'Dracula is an old book, so the word tonight is written to-night. Tonight we know how to write both tonight and to-night.');
 {['tonight'], ['to-night'], ['Tonight'], ['tonight'], ['to-night']}
 ```

--- a/translations/zh/chapter17/index.md
+++ b/translations/zh/chapter17/index.md
@@ -166,7 +166,7 @@ set {
 
 现在，让我们用上面的方法给 `The Demeter`（德古拉前往伦敦时乘坐的船）上放一些棺材：
 
-```edgeql-repl
+```
 db> update HasNameAndCoffins filter .name = <str>$place_name
 ....... set {
 .......   coffins := .coffins + <int16>$number

--- a/translations/zh/chapter20/index.md
+++ b/translations/zh/chapter20/index.md
@@ -97,7 +97,7 @@ error: possibly more than one element returned by an expression for a computed l
 
 所以对于用户遍布全球的数据库来说，`datetime` 通常是最好的选择。然后，你可以使用 {eql:func}`docs:std::to_datetime` 之类的函数将五个 `int64`、一个 `float64`（用于秒）和一个 `str`（用于 [the timezone](https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations)）转换为一个总是作为 UTC 返回的 `datetime`：
 
-```edgeql-repl
+```
 db> select std::to_datetime(2020, 10, 12, 15, 35, 5.5, 'KST');
 ....... # October 12 2020, 3:35 pm and 5.5 seconds in Korea (KST = Korean Standard Time)
 {<datetime>'2020-10-12T06:35:05.500Z'} # The return value is UTC, 6:35 (plus 5.5 seconds) in the morning

--- a/translations/zh/chapter5/index.md
+++ b/translations/zh/chapter5/index.md
@@ -25,7 +25,7 @@ leadImage: illustration_05.jpg
 
 顺便说一下，你可能会留意到一个不太熟悉的、名为 {eql:type}` ``decimal`` <docs:std::decimal>` 的类型。这是一个具有“任意精度”的浮点数，这意味着你可以根据需要在小数点后给出任意数量的数字。计算机上的浮点类型会由于舍入错误，在一段时间后 [变得不精确](https://www.youtube.com/watch?v=PZRI1IfStY0&ab_channel=Computerphile)。比如下面的例子：
 
-```edgeql-repl
+```
 db> select 6.777777777777777; # Good so far
 {6.777777777777777}
 db> select 6.7777777777777777; # Add one more digit...
@@ -34,7 +34,7 @@ db> select 6.7777777777777777; # Add one more digit...
 
 如果你想避免这个问题，就在末尾添加一个 `n` 以获得一个 `decimal` 类型，它将尽可能做到精确。
 
-```edgeql-repl
+```
 db> select 6.7777777777777777n;
 {6.7777777777777777n}
 db> select 6.7777777777777777777777777777777777777777777777777n;
@@ -43,7 +43,7 @@ db> select 6.7777777777777777777777777777777777777777777777777n;
 
 同时，还有一个 `bigint` 类型，也可以使用 `n` 来表示任意大小。那是因为即使 int64 也有上限：它是 9223372036854775807。
 
-```edgeql-repl
+```
 db> select 9223372036854775807; # Good so far...
 {9223372036854775807}
 db> select 9223372036854775808; # But add 1 and it will fail
@@ -52,7 +52,7 @@ ERROR: NumericOutOfRangeError: std::int64 out of range
 
 所以这里你可以加上一个 `n`，它将会创建一个可以容纳任何大小的 `bigint`。
 
-```edgeql-repl
+```
 db> select 9223372036854775808n;
 {9223372036854775808n}
 ```

--- a/translations/zh/chapter6/index.md
+++ b/translations/zh/chapter6/index.md
@@ -150,7 +150,7 @@ type Vampire extending Person {
 - 会使事情变得复杂。假设我们声明的 `Vampire` 里包含一个指向 `MinorVampire` 的 `slaves` 链接，在我们插入 `Vampire` 时，如果我们还没有创建对应的 `MinorVampire`，那么它将是空 `{}`，则我们将不得不在创建 `MinorVampire` 后，再对 `Vampire` 进行更新；如果我们先创建的是 `MinorVampire`，且它有一个指向 `Vampire` 的 `master` 链接，而我们还没有创建 `Vampire`，那么这个 `master` 将不存在，尤其当它是个 `required` link 时，我们必须提供一个 `master`。
 - 如果这两种类型相互链接，我们将无法在需要时删除它们。删除时的错误提示如下所示：
 
-```edgeql-repl
+```
 db> delete MinorVampire;
 ERROR: ConstraintViolationError: deletion of default::MinorVampire (ee6ca100-006f-11ec-93a9-4b5d85e60114) is prohibited by link target policy
   Detail: Object is still referenced in link slave of default::Vampire (e5ef5bc6-006f-11ec-93a9-77e907d251d6).

--- a/translations/zh/chapter9/index.md
+++ b/translations/zh/chapter9/index.md
@@ -86,7 +86,7 @@ type NPC extending Person {
 
 这里介绍一个方便实用的的函数，即 {eql:func}` ``datetime_current()`` <docs:std::datetime_current>`，它可以给出当前的日期时间。让我们试试看：
 
-```edgeql-repl
+```
 db> select datetime_current();
 {<datetime>'2020-11-17T06:13:24.418765000Z'}
 ```


### PR DESCRIPTION
Quick fix: for some reason blocks annotated with `edgeql-repl` are not displaying on https://www.edgedb.com/easy-edgedb/ so removing the annotation for the time being so that they will at least be visible.