### PR TITLE
Make Time global, change later global type to different enum, other rewriting

### DIFF
--- a/chapter10/code.md
+++ b/chapter10/code.md
@@ -3,6 +3,10 @@
 
 module default {
 
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -90,7 +94,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   }
 
@@ -100,6 +104,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter11/code.md
+++ b/chapter11/code.md
@@ -3,6 +3,10 @@
 
 module default {
 
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -102,7 +106,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -126,6 +130,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter12/code.md
+++ b/chapter12/code.md
@@ -3,6 +3,10 @@
 
 module default {
 
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -102,7 +106,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   }
 
@@ -140,6 +144,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter13/code.md
+++ b/chapter13/code.md
@@ -3,6 +3,10 @@
 
 module default {
 
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -109,7 +113,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -149,6 +153,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter14/code.md
+++ b/chapter14/code.md
@@ -5,8 +5,8 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13';
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
 
   abstract annotation warning;
@@ -14,6 +14,8 @@ module default {
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
+
+  scalar type Mode extending enum<Info, Debug>;
 
   scalar type PCNumber extending sequence;
 
@@ -121,7 +123,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -161,6 +163,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter15/code.md
+++ b/chapter15/code.md
@@ -5,15 +5,19 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13'
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
+
+  global time := assert_single((select Time));
 
   abstract annotation warning;
 
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
+
+  scalar type Mode extending enum<Info, Debug>;
 
   scalar type PCNumber extending sequence;
 
@@ -128,7 +132,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -185,6 +189,8 @@ module default {
 }
     
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter16/code.md
+++ b/chapter16/code.md
@@ -5,15 +5,19 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13';
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
+
+  global time := assert_single((select Time));
 
   abstract annotation warning;
 
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
+
+  scalar type Mode extending enum<Info, Debug>;
 
   scalar type PCNumber extending sequence;
 
@@ -151,7 +155,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -198,6 +202,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter17/code.md
+++ b/chapter17/code.md
@@ -5,9 +5,11 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13';
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
+
+  global time := assert_single((select Time));
 
   abstract annotation warning;
 
@@ -16,6 +18,8 @@ module default {
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
 
   scalar type LotteryTicket extending enum <Nothing, WallChicken, ChainWhip, Crucifix, Garlic>;
+
+  scalar type Mode extending enum<Info, Debug>;
   
   scalar type PCNumber extending sequence;
 
@@ -159,7 +163,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -226,6 +230,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter18/code.md
+++ b/chapter18/code.md
@@ -5,9 +5,11 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13';
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
+
+  global time := assert_single((select Time));
 
   abstract annotation warning;
 
@@ -16,6 +18,8 @@ module default {
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
 
   scalar type LotteryTicket extending enum <Nothing, WallChicken, ChainWhip, Crucifix, Garlic>;
+
+  scalar type Mode extending enum<Info, Debug>;
 
   scalar type PCNumber extending sequence;
 
@@ -230,7 +234,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -297,6 +301,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 for city_name in {'Munich', 'London'}
 union (

--- a/chapter19/code.md
+++ b/chapter19/code.md
@@ -5,9 +5,11 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13';
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
+
+  global time := assert_single((select Time));
 
   abstract annotation warning;
 
@@ -16,6 +18,8 @@ module default {
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
 
   scalar type LotteryTicket extending enum <Nothing, WallChicken, ChainWhip, Crucifix, Garlic>;
+
+  scalar type Mode extending enum<Info, Debug>;
 
   scalar type PCNumber extending sequence;
 
@@ -241,14 +245,15 @@ module default {
     clock: str;
     property clock_time := <cal::local_time>.clock;
     property hour := .clock[0:2];
-    property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+          else SleepState.Awake;
   }
 
   type Time { 
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   }
 
@@ -315,6 +320,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 for city_name in {'Munich', 'London'}
 union (

--- a/chapter19/index.md
+++ b/chapter19/index.md
@@ -244,7 +244,7 @@ type Time {
   required clock: str; 
   property clock_time := <cal::local_time>.clock; 
   property hour := .clock[0:2]; 
-  property sleep_state := 
+  property vampires_are := 
     SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
     else SleepState.Awake;
 } 
@@ -270,7 +270,7 @@ select ShipVisit {
     clock,
     clock_time,
     hour,
-    sleep_state
+    vampires_are
   },
 } filter .place.name = 'Galatz';
 ```
@@ -287,7 +287,7 @@ The output looks pretty good, including whether vampires were awake or asleep wh
       clock: '13:00:00',
       clock_time: <cal::local_time>'13:00:00',
       hour: '13',
-      sleep_state: Asleep,
+      vampires_are: Asleep,
     },
   },
 }
@@ -299,9 +299,9 @@ However, the problem is that we now have a random `Time` type floating around th
 function time(clock: str) -> tuple<cal::local_time, str, SleepState> using (
   with local := <cal::local_time>clock,
   hour := clock[0:2],
-  sleep_state := SleepState.Asleep if <int16>hour > 7 and <int16>hour < 19
+  vampires_are := SleepState.Asleep if <int16>hour > 7 and <int16>hour < 19
     else SleepState.Awake,
-    select(local, hour, sleep_state)
+    select(local, hour, vampires_are)
 );
 ```
 
@@ -315,7 +315,8 @@ type ShipVisit {
   clock: str;
   property clock_time := <cal::local_time>.clock;
   property hour := .clock[0:2];
-  property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+  property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+        else SleepState.Awake;
 }
 ```
 
@@ -339,7 +340,7 @@ select ShipVisit {
   clock,
   when_arthur_got_the_telegram := <cal::local_time>.clock + duration,
   hour,
-  sleep_state
+  vampires_are
 } filter .place.name = 'Galatz';
   
 ```
@@ -354,7 +355,7 @@ And now we get all the output that the `Time` type gave us before, plus our extr
     date: <cal::local_date>'1893-10-28',
     clock: '13:00:00',
     hour: '13',
-    sleep_state: 'asleep',
+    vampires_are: Asleep,
     when_arthur_got_the_telegram: <cal::local_time>'15:05:10',
   },
 }

--- a/chapter20/code.md
+++ b/chapter20/code.md
@@ -5,9 +5,11 @@ module default {
 
   # Globals and definitions
 
-  required global current_date: cal::local_date {
-    default := <cal::local_date>'1893-05-13';
+  required global tester_mode: Mode {
+    default := Mode.Info;
   }
+
+  global time := assert_single((select Time));
 
   abstract annotation warning;
 
@@ -16,6 +18,8 @@ module default {
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
 
   scalar type LotteryTicket extending enum <Nothing, WallChicken, ChainWhip, Crucifix, Garlic>;
+
+  scalar type Mode extending enum<Info, Debug>;
 
   scalar type PCNumber extending sequence;
 
@@ -241,14 +245,15 @@ module default {
     clock: str;
     property clock_time := <cal::local_time>.clock;
     property hour := .clock[0:2];
-    property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+      else SleepState.Awake;
   }
 
   type Time { 
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -317,6 +322,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 for city_name in {'Munich', 'London'}
 union (

--- a/chapter20/index.md
+++ b/chapter20/index.md
@@ -191,7 +191,7 @@ select {'Total PCs created: ' ++ latest ++ ' Current PCs: ' ++ <str>count(PC) };
 
 - by casting it into a {eql:type}`docs:cal::local_time` to make the `clock_time` property,
 - by slicing its first two characters to get the `hour` property, which is just a string. This is only possible because we know that even single digit numbers like `1` need to be written with two digits: `01`
-- by another computed property called `sleep_state` that is either 'asleep' or 'awake' depending on the `hour` property we just made, cast into an `int16`.
+- by another computed property called `vampires_are` that is either `Asleep` or `Awake` depending on the `hour` property we just made, cast into an `int16`.
 
 ```sdl
 type ShipVisit {
@@ -201,8 +201,8 @@ type ShipVisit {
   clock: str;
   property clock_time := <cal::local_time>.clock;
   property hour := .clock[0:2];
-  property sleep_state := 'asleep' 
-    if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+  property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+        else SleepState.Awake;
 }
 ```
 

--- a/chapter4/code.md
+++ b/chapter4/code.md
@@ -2,6 +2,11 @@
 # Schema:
 
 module default {
+
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -9,6 +14,8 @@ module default {
   scalar type HumanAge extending int16 {
     constraint max_value(120);
   }
+
+  scalar type SleepState extending enum <Asleep, Awake>;
 
   # Abstract object types
 
@@ -43,7 +50,8 @@ module default {
     required clock: str;
     property clock_time := <cal::local_time>.clock;
     property hour := .clock[0:2];
-    property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+          else SleepState.Awake;
   }
 
   type Vampire extending Person {
@@ -52,6 +60,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter5/code.md
+++ b/chapter5/code.md
@@ -2,6 +2,11 @@
 # Schema:
 
 module default {
+
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -49,7 +54,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -59,6 +64,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter6/code.md
+++ b/chapter6/code.md
@@ -2,6 +2,10 @@
 # Schema:
 
 module default {
+
+  # Globals
+
+  global time := assert_single((select Time));
   
   # Scalar types
 
@@ -52,7 +56,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   }
 
@@ -64,6 +68,8 @@ module default {
 
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter7/code.md
+++ b/chapter7/code.md
@@ -2,6 +2,11 @@
 # Schema:
 
 module default {
+
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
 
@@ -59,12 +64,14 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter7/index.md
+++ b/chapter7/index.md
@@ -289,7 +289,7 @@ with time := (
  clock,
  clock_time,
  hour,
- sleep_state
+ vampires_are
  };
 Parameter <str>$hour: 10
 Parameter <str>$minute: 09
@@ -304,7 +304,7 @@ And the output:
     clock: '100909',
     clock_time: <cal::local_time>'10:09:09',
     hour: '10',
-    sleep_state: 'asleep',
+    vampires_are: Asleep,
   },
 }
 ```

--- a/chapter8/code.md
+++ b/chapter8/code.md
@@ -3,6 +3,10 @@
 
 module default {
 
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -77,7 +81,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -88,6 +92,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/chapter9/code.md
+++ b/chapter9/code.md
@@ -3,6 +3,10 @@
 
 module default {
 
+  # Globals
+
+  global time := assert_single((select Time));
+
   # Scalar types
 
   scalar type Class extending enum<Rogue, Mystic, Merchant>;
@@ -84,7 +88,7 @@ module default {
     required clock: str; 
     property clock_time := <cal::local_time>.clock; 
     property hour := .clock[0:2]; 
-    property sleep_state := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+    property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
       else SleepState.Awake;
   } 
 
@@ -94,6 +98,8 @@ module default {
 }
 
 # Data:
+
+insert Time { clock := '09:00:00' };
 
 insert City {
   name := 'Munich',

--- a/translations/zh/chapter19/index.md
+++ b/translations/zh/chapter19/index.md
@@ -192,11 +192,12 @@ type Time {
   required clock: str;
   property clock_time := <cal::local_time>.clock;
   property hour := .clock[0:2];
-  property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+  property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+        else SleepState.Awake;
 }
 ```
 
-电报里提到的抵达时间是下午 1 点钟，让我们将该信息也放入到查询中，并获取包括 `sleep_state` 属性在内的时间信息。如下所示：
+电报里提到的抵达时间是下午 1 点钟，让我们将该信息也放入到查询中，并获取包括 `vampires_are` 属性在内的时间信息。如下所示：
 
 ```edgeql
 with time := (
@@ -216,7 +217,7 @@ select Ship.<ship[is ShipVisit] {
     clcok,
     clock_time,
     hour,
-    sleep_state
+    vampires_are
   },
 } filter .place.name = 'Galatz';
 ```
@@ -233,7 +234,7 @@ select Ship.<ship[is ShipVisit] {
       clock: '13:00:00',
       clock_time: <cal::local_time>'13:00:00',
       hour: '13',
-      sleep_state: 'asleep',
+      vampires_are: Asleep,
     },
   },
 }
@@ -251,7 +252,8 @@ type ShipVisit {
   clock: str;
   property clock_time := <cal::local_time>.clock;
   property hour := .clock[0:2];
-  property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+  property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+        else SleepState.Awake;
 }
 ```
 
@@ -277,7 +279,7 @@ select Ship.<ship[is ShipVisit] {
   date,
   clock,
   hour,
-  sleep_state,
+  vampires_are,
   when_arthur_got_the_telegram := (<cal::local_time>.clock) + <duration>'2 hours, 5 minutes, 10 seconds'
 } filter .place.name = 'Galatz';
 ```
@@ -292,7 +294,7 @@ select Ship.<ship[is ShipVisit] {
     date: <cal::local_date>'1893-10-28',
     clock: '13:00:00',
     hour: '13',
-    sleep_state: 'asleep',
+    vampires_are: Asleep,
     when_arthur_got_the_telegram: <cal::local_time>'15:05:10',
   },
 }

--- a/translations/zh/chapter20/index.md
+++ b/translations/zh/chapter20/index.md
@@ -170,7 +170,7 @@ type PC extending Person {
 
 - 将其转换为 {eql:type}`docs:cal::local_time` 并赋予属性 `clock_time`，
 - 使用切片获取它的前两个字符来并赋予属性 `hour`。因为它是一个字符串，所以即使像 `1` 这样的单个数字也需要用两位数书写，即“01”，以适应“小时数”的获取方式，
-- 由另一个名为 `sleep_state` 的计算（computed）属性决定此时的吸血鬼状态是 'asleep' 还是 'awake'，这取决于我们上一条中的 `hour` 属性，且需要将其先转换为 `<int16>`。
+- 由另一个名为 `vampires_are` 的计算（computed）属性决定此时的吸血鬼状态是 'asleep' 还是 'awake'，这取决于我们上一条中的 `hour` 属性，且需要将其先转换为 `<int16>`。
 
 ```sdl
 type ShipVisit {
@@ -180,7 +180,8 @@ type ShipVisit {
   clock: str;
   property clock_time := <cal::local_time>.clock;
   property hour := .clock[0:2];
-  property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else 'awake';
+  property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+        else SleepState.Awake;
 }
 ```
 

--- a/translations/zh/chapter4/index.md
+++ b/translations/zh/chapter4/index.md
@@ -216,27 +216,27 @@ type Time {
   required clock: str;
   property clock_time := <cal::local_time>.clock;
   property hour := .clock[0:2];
-  property sleep_state := 'asleep' if <int16>.hour > 7 and <int16>.hour < 19
-    else 'awake';
+  property vampires_are := SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19
+        else SleepState.Awake;
 }
 ```
 
-因此，`sleep_state` 是如下这样计算的：
+因此，`vampires_are` 是如下这样计算的：
 
 - 首先 EdgeDB 会查看取到的小时的数值是否大于 7 且小于 19（晚上 7 点）。这里用两个数字进行比较比用数字与字符串进行比较要好，因此我们编写 `<int16>.hour` 而不是 `.hour`，这样就可以通过类型转换达到用数字与数字进行比较的目的。
 - 然后 EdgeDB 会基于比较结果给出一个字符串来说明现在的状态是“睡着（'asleep'）”还是“醒着（'awake'）”。
 
 现在，如果我们对所有属性进行 `select`，我们将得到：
 
-`{default::Time {clock: '09:55:05', clock_time: <cal::local_time>'09:55:05', hour: '09', sleep_state: 'asleep'}}`
+`{default::Time {clock: '09:55:05', clock_time: <cal::local_time>'09:55:05', hour: '09', vampires_are: Asleep}}`
 
 关于 `else`，这里有一个注意事项：你可以在 `(result) if (condition) else` 格式中根据需要多次使用 `else`。例如：
 
 ```
-property sleep_state := 'just waking up' if <int16>.hour = 19 else
-                  'going to bed' if <int16>.hour = 6 else
-                  'asleep' if <int16>.hour > 7 and <int16>.hour < 19 else
-                  'awake';
+property vampires_are := SleepState.JustWakingUp if <int16>.hour = 19 else
+                  SleepState.GoingToBed if <int16>.hour = 6 else
+                  SleepState.Asleep if <int16>.hour > 7 and <int16>.hour < 19 else
+                  SleepState.Awake;
 ```
 
 ## 插入的同时做选择
@@ -262,12 +262,12 @@ select ( # Start a selection
   { # Now just choose the properties we want
     clock,
     hour,
-    sleep_state,
+    vampires_are,
     double_hour := <int16>.hour * 2
   };
 ```
 
-现在的输出结果对我们来说更有意义了，即：`{default::Time {clock: '22:44:10', hour: '22', sleep_state: 'awake', double_hour: 44}}`。我们知道了时间（clock）和小时（hour），同时也了解到了吸血鬼是醒着的，我们甚至可以对我们刚刚输入的对象做些其他计算，如示例中的 `double_hour`。
+现在的输出结果对我们来说更有意义了，即：`{default::Time {clock: '22:44:10', hour: '22', vampires_are: Awake, double_hour: 44}}`。我们知道了时间（clock）和小时（hour），同时也了解到了吸血鬼是醒着的，我们甚至可以对我们刚刚输入的对象做些其他计算，如示例中的 `double_hour`。
 
 [→ 点击这里查看到第 4 章为止的所有代码](code.md)
 

--- a/translations/zh/chapter7/index.md
+++ b/translations/zh/chapter7/index.md
@@ -242,7 +242,7 @@ select (
   clock,
   clock_time,
   hour,
-  sleep_state
+  vampires_are
 };
 Parameter <str>$hour: 10
 Parameter <str>$minute: 09
@@ -257,7 +257,7 @@ Parameter <str>$second: 09
     clock: '100909',
     clock_time: <cal::local_time>'10:09:09',
     hour: '10',
-    sleep_state: 'asleep',
+    vampires_are: Asleep,
   },
 }
 ```


### PR DESCRIPTION
This is the first of a few PRs to deal with parts of the original book that I find dissatisfying. One of them is the `Time` type which never really did anything except float around as a few objects unrelated to anything else. Was going to delete it but it seems like a good way to introduce globals earlier on so this part has been rewritten in Chapter 4. Chapter 14 has its own time-related global scalar though so this has also been changed to another global: an enum that differentiates between Info and Debug mode (e.g. so a game tester can select between testing the game as a regular player vs. testing the game with extra info).

Will add examples of updating the global Time object and a constraint to disallow any inserts past the first one but this branch has quite a few changes already so will merge first.