### PR TITLE
Update can_enter function

### DIFF
--- a/chapter15/code.md
+++ b/chapter15/code.md
@@ -172,7 +172,7 @@ module default {
 
   function can_enter(person_name: str, place: HasCoffins) -> optional str
     using (
-      with vampire := (select Person filter .name = person_name),
+      with vampire := assert_single((select Person filter .name = person_name)),
       has_coffins := place.coffins > 0,
         select vampire.name ++ ' can enter.' if has_coffins else vampire.name ++ ' cannot enter.'
   );

--- a/chapter15/index.md
+++ b/chapter15/index.md
@@ -65,7 +65,7 @@ If we want, we can now make a quick function to test whether a vampire can enter
 ```sdl
 function can_enter(person_name: str, place: HasCoffins) -> optional str
   using (
-    with vampire := (select Person filter .name = person_name),
+    with vampire := assert_single((select Person filter .name = person_name)),
     has_coffins := place.coffins > 0,
       select vampire.name ++ ' can enter.' 
         if has_coffins else vampire.name ++ ' cannot enter.'
@@ -161,7 +161,7 @@ type Ship extending HasCoffins {
 
 function can_enter(person_name: str, place: HasCoffins) -> optional str
   using (
-    with vampire := (select Person filter .name = person_name),
+    with vampire := assert_single((select Person filter .name = person_name)),
     has_coffins := place.coffins > 0,
       select vampire.name ++ ' can enter.' if has_coffins else vampire.name ++ ' cannot enter.'
     );

--- a/chapter16/code.md
+++ b/chapter16/code.md
@@ -186,7 +186,7 @@ module default {
 
   function can_enter(person_name: str, place: HasCoffins) -> optional str
     using (
-      with vampire := (select Person filter .name = person_name),
+      with vampire := assert_single((select Person filter .name = person_name)),
       has_coffins := place.coffins > 0,
         select vampire.name ++ ' can enter.' if has_coffins else vampire.name ++ ' cannot enter.'
     );

--- a/chapter17/index.md
+++ b/chapter17/index.md
@@ -82,7 +82,7 @@ Finally, we can change our `can_enter()` function. This one needed a `HasCoffins
 ```sdl
 function can_enter(person_name: str, place: HasCoffins) -> optional str
   using (
-    with vampire := (select Person filter .name = person_name),
+    with vampire := assert_single((select Person filter .name = person_name)),
     has_coffins := place.coffins > 0,
       select vampire.name ++ ' can enter.'
         if has_coffins else vampire.name ++ ' cannot enter.'

--- a/translations/zh/chapter15/index.md
+++ b/translations/zh/chapter15/index.md
@@ -61,7 +61,7 @@ type Ship extending HasCoffins {
 ```sdl
 function can_enter(person_name: str, place: HasCoffins) -> optional str
   using (
-    with vampire := (select Person filter .name = person_name),
+    with vampire := assert_single((select Person filter .name = person_name)),
     has_coffins := place.coffins > 0,
       select vampire.name ++ ' can enter.' if has_coffins else vampire.name ++ ' cannot enter.'
     );

--- a/translations/zh/chapter17/index.md
+++ b/translations/zh/chapter17/index.md
@@ -131,7 +131,7 @@ abstract type Place extending HasNameAndCoffins {
 ```sdl
 function can_enter(person_name: str, place: HasCoffins) -> optional str
   using (
-    with vampire := (select Person filter .name = person_name),
+    with vampire := assert_single((select Person filter .name = person_name)),
     has_coffins := place.coffins > 0,
       select vampire.name ++ ' can enter.' if has_coffins else vampire.name ++ ' cannot enter.'
     );


### PR DESCRIPTION
This PR is prompted by the discovery that the provided code in chapters 15 and 16 is unable to migrate successfully. This issue stems from the absence of an `assert_single` for `Vampire` in the `can_enter` function.

Interestingly, this problem is resolved in chapter 17. The modification in chapter 17 includes an update to the `can_enter` function, where an `assert_single` for `Vampire` has been added.